### PR TITLE
Fix compilation for G++4.7 on Ubuntu 13.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories("${PROJECT_SOURCE_DIR}")
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ./bin)
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -stdlib=libc++ -Wfatal-errors -Wall -W -Werror -Wfloat-equal -Wundef -Wendif-labels -Wshadow -pedantic-errors")
+set(CMAKE_CXX_FLAGS "-std=c++11 -Wfatal-errors -Wall -W -Werror -Wfloat-equal -Wundef -Wendif-labels")
 
 FILE(GLOB BanditSpecSourceFiles specs/*.cpp specs/**/*.cpp)
 add_executable(bandit-specs ${BanditSpecSourceFiles} )

--- a/bandit/bandit.h
+++ b/bandit/bandit.h
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <list>
 #include <deque>
+#include <stdexcept>
 
 namespace bandit { namespace detail {
   typedef std::function<void ()> voidfunc_t;

--- a/specs/util/argv_helper.h
+++ b/specs/util/argv_helper.h
@@ -1,6 +1,8 @@
 #ifndef BANDIT_SPECS_ARGV_HELPER_H
 #define BANDIT_SPECS_ARGV_HELPER_H
 
+#include <string.h>
+
 namespace bandit { namespace specs { namespace util {
 
   //


### PR DESCRIPTION
Ubuntu is shipped with G++4.7
To run Bandit specs with G++4.7, I needed to:
- update compile flags via CMakeLists.txt
- add <stdexcept> header to bandit.h (otherwise, got and error with assertion_exception.h)
- add <string.h> header to specs/util/argv_helper.h in order to use strlen
