### PR TITLE
Add Travis configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: cpp
+compiler:
+  - gcc
+  - clang
+before_script:
+  - BUILD_DIR=`pwd`/builds
+  - mkdir -p ${BUILD_DIR}
+  - cd ${BUILD_DIR}
+  - cmake ..
+script:
+  - cd ${BUILD_DIR}
+  - make


### PR DESCRIPTION
Travis configuration to build and run specs with both clang and gcc
