### PR TITLE
minimize dependencies from windows.h

### DIFF
--- a/bandit/reporters/colorizer.h
+++ b/bandit/reporters/colorizer.h
@@ -2,6 +2,7 @@
 #define BANDIT_REPORTERS_COLORIZER_H
 
 #ifdef _WIN32
+  #define NOMINMAX
   #define WIN32_LEAN_AND_MEAN
   #include <windows.h>
 #endif


### PR DESCRIPTION
# include <bandit/bandit.h> before the winsock2 generates large amount of redefinition errors originating from conflicts between winsock.h and winsock2.h. Root cause is winsock.h included from the windows.h
