### PR TITLE
Added xit and xdescribe

### DIFF
--- a/bandit/grammar.h
+++ b/bandit/grammar.h
@@ -46,6 +46,13 @@ namespace bandit {
         detail::context_stack());
   }
 
+  inline void xdescribe(const char* desc, detail::voidfunc_t func,
+      detail::listener& listener=detail::registered_listener(),
+      detail::contextstack_t& context_stack=detail::context_stack())
+  {
+    describe_skip(desc, func, listener, context_stack);
+  }
+
   inline void before_each(detail::voidfunc_t func, 
       detail::contextstack_t& context_stack)
   {
@@ -76,6 +83,11 @@ namespace bandit {
   inline void it_skip(const char* desc, detail::voidfunc_t func)
   {
     it_skip(desc, func, detail::registered_listener());
+  }
+
+  inline void xit(const char* desc, detail::voidfunc_t func, detail::listener& listener=detail::registered_listener())
+  {
+    it_skip(desc, func, listener);
   }
 
   inline void it(const char* desc, detail::voidfunc_t func, detail::listener& listener,

--- a/specs/describe.spec.cpp
+++ b/specs/describe.spec.cpp
@@ -102,6 +102,15 @@ go_bandit([](){
         });
       
       });
+
+      describe("xdescribe", [&](){
+
+        it("pushes a context marked as skipped on the stack", [&](){
+          xdescribe("context name", describe_fn, *reporter, *context_stack);
+          AssertThat(context_is_hard_skip, IsTrue());
+        });
+
+      });
     });
   });
 

--- a/specs/it.spec.cpp
+++ b/specs/it.spec.cpp
@@ -251,6 +251,21 @@ go_bandit([](){
     
     });
 
+    describe("xit", [&](){
+
+      it("tells reporter it's skipped", [&](){
+        xit("my it", [](){}, *reporter);
+        AssertThat(reporter->call_log(), Has().Exactly(1).EqualTo("it_skip: my it"));
+      });
+
+      it("doesn't call function", [&](){
+        bool called = false;
+        xit("my it", [&](){ called = true; }, *reporter);
+        AssertThat(called, IsFalse());
+      });
+
+    });
+
     describe("with a run policy that says to skip this 'it'", [&](){
         bool it_was_called;
 


### PR DESCRIPTION
Syntactic sugar for easier skipping, and for being more like RSpec.

I used parameter defaults for the new xit and xdescribe functions instead of making overloads. It seemed cleaner that way. If you prefer the overloaded functions I can rework the commit.
