### PR TITLE
Adopt Cedar's SPEC_BEGIN/SPEC_END construct

### DIFF
--- a/bandit/registration/registrar.h
+++ b/bandit/registration/registrar.h
@@ -16,4 +16,10 @@ namespace bandit { namespace detail {
 #define go_bandit \
   static bandit::detail::spec_registrar bandit_registrar
 
+#define SPEC_BEGIN(name)    \
+go_bandit([]{
+
+#define SPEC_END            \
+});
+
 #endif

--- a/specs/describe.spec.cpp
+++ b/specs/describe.spec.cpp
@@ -3,7 +3,7 @@
 using namespace bandit::fakes;
 namespace bd = bandit::detail;
 
-go_bandit([](){
+SPEC_BEGIN(describe)
 
   describe("describe:", [](){
     bandit::detail::voidfunc_t describe_fn;
@@ -114,4 +114,4 @@ go_bandit([](){
     });
   });
 
-});
+SPEC_END


### PR DESCRIPTION
Optionally allow SPEC_BEGIN and SPEC_END to be used instead of the go_bandit() construct.

I'm borrowing this from the [Cedar](https://github.com/pivotal/cedar) project. I feel it helps make the test syntax more generic because it doesn't require the tests to include the name of the test framework. Granted, the `using` statements still have the framework name, but they can always be hidden in the helper header.
