### PR TITLE
Fix colorizer for Windows

### DIFF
--- a/bandit/reporters/colorizer.h
+++ b/bandit/reporters/colorizer.h
@@ -35,7 +35,7 @@ namespace bandit { namespace detail {
     {
       if(colors_enabled_)
 	  {
-		  set_console_color(FOREGROUND_YELLOW);
+		  set_console_color(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY);
 	  }
 	  return "";
     }
@@ -62,7 +62,7 @@ namespace bandit { namespace detail {
     {
       if(colors_enabled_)
 	  {
-		  set_console_color(FOREGROUND_WHITE);
+		  set_console_color(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY);
 	  }
 	  return "";
     }


### PR DESCRIPTION
The yellow and white colors does not exists in the windows.h header. Instead, those colors needs to be composed from basic colors as flags. The intensity flag is required to get from orange and grey to yellow and white.
