### PR TITLE
Add line break in default error formatter

### DIFF
--- a/bandit/failure_formatters/default_failure_formatter.h
+++ b/bandit/failure_formatters/default_failure_formatter.h
@@ -20,7 +20,7 @@ namespace bandit { namespace detail {
         ss << ": ";
       }
 
-      ss << err.what();
+      ss << std::endl << err.what();
 
       return ss.str();
     }


### PR DESCRIPTION
This is related to a previous PR I submitted, #36, but better I think. And this time it's in bandit code, not in snowhouse.

Before:

```
My object has some behavior:
/some/very-long/path/to/the-test.cc:154: Expected: equal to #<value-1>
Actual: #<value-2>
```

After:

```
My object has some behavior:
/some/very-long/path/to/the-test.cc:154:
Expected: equal to #<value-1>
Actual: #<value-2>
```
