### PR TITLE
Things build and run on vs2015

### DIFF
--- a/bandit/assertion_frameworks/matchers/must.h
+++ b/bandit/assertion_frameworks/matchers/must.h
@@ -30,7 +30,7 @@ namespace bandit { namespace Matchers
     }
 }}
 
-#define must	    ,(bandit::Matchers::ValueMarker){__FILE__, __LINE__},false,
-#define must_not    ,(bandit::Matchers::ValueMarker){__FILE__, __LINE__},true,
+#define must	    ,(bandit::Matchers::ValueMarker {__FILE__, __LINE__}),false,
+#define must_not    ,(bandit::Matchers::ValueMarker {__FILE__, __LINE__}),true,
 
 #endif	//BANDIT_MUST_H

--- a/specs/matchers/equal.cpp
+++ b/specs/matchers/equal.cpp
@@ -2,8 +2,10 @@
 
 using namespace bandit::Matchers;
 
-#ifdef _MSC_VER && !defined(__clang__)
+#ifndef __clang__
+#ifdef _MSC_VER 
 	static char *stpcpy(char *dest, const char *src) { strcpy(dest, src); return dest + strlen(dest); }
+#endif
 #endif
 
 SPEC_BEGIN(Matchers::Equal)

--- a/specs/matchers/equal.cpp
+++ b/specs/matchers/equal.cpp
@@ -2,7 +2,9 @@
 
 using namespace bandit::Matchers;
 
-static char *stpcpy(char *dest, const char *src) { strcpy(dest, src); return dest + strlen(dest); }
+#ifdef _MSC_VER && !defined(__clang__)
+	static char *stpcpy(char *dest, const char *src) { strcpy(dest, src); return dest + strlen(dest); }
+#endif
 
 SPEC_BEGIN(Matchers::Equal)
 

--- a/specs/matchers/equal.cpp
+++ b/specs/matchers/equal.cpp
@@ -2,6 +2,8 @@
 
 using namespace bandit::Matchers;
 
+static char *stpcpy(char *dest, const char *src) { strcpy(dest, src); return dest + strlen(dest); }
+
 SPEC_BEGIN(Matchers::Equal)
 
 describe("when the actual value is a built-in type", []{

--- a/specs/matchers/throw_exception.cpp
+++ b/specs/matchers/throw_exception.cpp
@@ -78,11 +78,11 @@ describe("throw_exception", []{
         describe("when the block throws an unrelated exception", [&]{
 	    std::function<void()> unrelated_block = [&]{ throw std::range_error("range error"); };
 
-	    it("must pass a negative match", [&]{
+	    it("must pass a negative match", [&unrelated_block, &expected_exception]{
 		unrelated_block must_not throw_exception.operator()<decltype(expected_exception)>();
 	    });
 
-	    it("must reject a positive match", [&]{
+	    it("must reject a positive match", [&unrelated_block, &expected_exception]{
 		AssertThrows(std::exception, [&]{ unrelated_block must throw_exception.operator()<decltype(expected_exception)>(); }());
 	    });
         });
@@ -90,11 +90,11 @@ describe("throw_exception", []{
         describe("when the block does not throw an exception", [&]{
 	    std::function<void()> quiet_block = [&]{};
 
-	    it("must pass a negative match", [&]{
+	    it("must pass a negative match", [&quiet_block, &expected_exception]{
 		quiet_block must_not throw_exception.operator()<decltype(expected_exception)>();
 	    });
 
-	    it("must reject a positive match", [&]{
+	    it("must reject a positive match", [&quiet_block, &expected_exception]{
 		AssertThrows(std::exception, [&]{ quiet_block must throw_exception.operator()<decltype(expected_exception)>(); }());
 	    });
         });


### PR DESCRIPTION
Hi Joakim,

I have made some changes that enabled me to build and run the tests using visual studio 2015.

I hope the changes to must and must_not make sense.

The compiler had a strange thing where it could not resolve decltype(expected_exception) without expected_exception being an explicit reference parameter.

I also had to modify the  CMakeLists.txt for snowhouse and add a msvc conditional for the warning flags so that would build.

Please take a look if this makes sense to use.