### PR TITLE
Fix and enhance info reporter

### DIFF
--- a/bandit/reporters/info_reporter.h
+++ b/bandit/reporters/info_reporter.h
@@ -177,6 +177,7 @@ struct info_reporter : public progress_reporter
 
 	virtual void it_skip(const char *desc)
 	{
+		progress_reporter::it_skip(desc);
 		++context_stack_.top().total;
 		++context_stack_.top().skipped;
 	}

--- a/bandit/reporters/info_reporter.h
+++ b/bandit/reporters/info_reporter.h
@@ -207,7 +207,7 @@ struct info_reporter : public progress_reporter
 	virtual void it_starting(const char *desc)
 	{
 		if (context_stack_.size() > 1
-		 && context_stack_.top().total == 0) {
+		 && context_stack_.top().total == context_stack_.top().skipped) {
 			output_not_yet_shown_context_start_messages();
 		}
 

--- a/bandit/reporters/info_reporter.h
+++ b/bandit/reporters/info_reporter.h
@@ -9,6 +9,12 @@ struct info_reporter : public progress_reporter
 	struct context_info
 	{
 		context_info(const char *d) : desc(d), total(0), skipped(0), failed(0) {}
+		void merge(const context_info &ci)
+		{
+			total += ci.total;
+			skipped += ci.skipped;
+			failed += ci.failed;
+		}
 		const char *desc;
 		int total;
 		int skipped;
@@ -131,7 +137,7 @@ struct info_reporter : public progress_reporter
 		  << "end "
 		  << colorizer_.reset()
 		  << desc;
-		const context_info &context = context_stack_.top();
+		const context_info context = context_stack_.top(); // copy
 		if (context.total > 0) {
 			stm_
 			  << colorizer_.white()
@@ -149,6 +155,9 @@ struct info_reporter : public progress_reporter
 		}
 		stm_ << colorizer_.reset() << std::endl;
 		context_stack_.pop();
+		if (!context_stack_.empty()) {
+			context_stack_.top().merge(context);
+		}
 	}
 
 	virtual void it_skip(const char *desc)

--- a/bandit/reporters/info_reporter.h
+++ b/bandit/reporters/info_reporter.h
@@ -294,6 +294,13 @@ struct info_reporter : public progress_reporter
 		stm_.flush();
 	}
 
+	bool did_we_pass() const
+	{
+		return
+		  specs_failed_ == 0 &&
+		  test_run_errors_.size() == 0;
+	}
+
 private:
 	std::string indent()
 	{

--- a/bandit/reporters/info_reporter.h
+++ b/bandit/reporters/info_reporter.h
@@ -62,7 +62,7 @@ struct info_reporter : public progress_reporter
 		if (test_run_errors_.size() > 0) {
 			stm_
 			  << colorizer_.red()
-			  << "List of run errors: "
+			  << "List of run errors:"
 			  << std::endl;
 			std::for_each(test_run_errors_.begin(), test_run_errors_.end(), [&](const std::string &error) {
 				stm_

--- a/specs/reporters/info_reporter.spec.cpp
+++ b/specs/reporters/info_reporter.spec.cpp
@@ -1,0 +1,377 @@
+#include <specs/specs.h>
+namespace bd = bandit::detail;
+
+go_bandit([](){
+  describe("info_reporter:", [&](){
+    std::unique_ptr<std::stringstream> stm;
+    std::unique_ptr<bd::info_reporter> reporter;
+    bd::default_failure_formatter formatter;
+    bd::colorizer colorizer(false);
+
+    before_each([&](){
+      stm = std::unique_ptr<std::stringstream>(new std::stringstream());
+      reporter = std::unique_ptr<bd::info_reporter>(new bd::info_reporter(*stm, formatter, colorizer));
+    });
+
+    auto output = [&](){ return stm->str(); };
+
+    describe("an empty test run", [&](){
+      before_each([&](){
+        reporter->test_run_starting();
+        reporter->test_run_complete();
+      });
+
+      it("reports no run tests in summary", [&](){
+        AssertThat(output(), Equals("\nTests run: 0\n\n"));
+      });
+
+      it_skip("is considered successful", [&](){
+        AssertThat(reporter->did_we_pass(), IsTrue());
+      });
+    });
+
+    describe("one successful test run", [&](){
+      before_each([&](){
+        reporter->test_run_starting();
+        reporter->context_starting("context");
+        reporter->it_starting("passes");
+        reporter->it_succeeded("passes");
+        reporter->context_ended("context");
+        reporter->test_run_complete();
+      });
+
+      it("shows the context", [&](){
+        AssertThat(output(), Contains("begin context"));
+        AssertThat(output(), Contains("end context"));
+      });
+
+      it("shows the context summary", [&](){
+        AssertThat(output(), Contains("end context 1 total"));
+      });
+
+      it("shows the passing test as passed", [&](){
+        AssertThat(output(), Contains("[ PASS ] it passes"));
+      });
+
+      it("reports one run test in the summary", [&](){
+        AssertThat(output(), Contains("Tests run: 1"));
+      });
+
+      it("reports one passed test in the summary", [&](){
+        AssertThat(output(), Contains("Passed: 1"));
+      });
+
+      it("does not report failed tests in the summary", [&](){
+        AssertThat(output(), !Contains("Failed: "));
+      });
+
+      it("does not report skipped tests", [&](){
+        AssertThat(output(), !Contains("Skipped: "));
+      });
+
+      it("ends successfully", [&](){
+        AssertThat(reporter->did_we_pass(), IsTrue());
+      });
+    });
+
+    describe("one successful and one failing test run", [&](){
+      before_each([&](){
+        reporter->test_run_starting();
+        reporter->context_starting("context");
+        reporter->it_starting("passes");
+        reporter->it_succeeded("passes");
+        reporter->it_starting("fails");
+        bd::assertion_exception exception("assertion failed!", "some_file", 123);
+        reporter->it_failed("fails", exception);
+        reporter->context_ended("context");
+        reporter->test_run_complete();
+      });
+
+      it("shows the context", [&](){
+        AssertThat(output(), Contains("begin context"));
+        AssertThat(output(), Contains("end context"));
+      });
+
+      it("shows the context summary", [&](){
+        AssertThat(output(), Contains("end context 2 total 1 failed"));
+      });
+
+      it("shows the passing test as passed", [&](){
+        AssertThat(output(), Contains("[ PASS ] it passes"));
+      });
+
+      it("shows the failing test as failed", [&](){
+        AssertThat(output(), Contains("[ FAIL ] it fails"));
+      });
+
+      it("reports two run tests", [&](){
+        AssertThat(output(), Contains("Tests run: 2"));
+      });
+
+      it("reports one passed test in the summary", [&](){
+        AssertThat(output(), Contains("Passed: 1"));
+      });
+
+      it("reports one failed test in the summary", [&](){
+        AssertThat(output(), Contains("Failed: 1"));
+      });
+
+      it("does not report skipped tests in the summary", [&](){
+        AssertThat(output(), !Contains("Skipped: "));
+      });
+
+      it("does not end successfully", [&](){
+        AssertThat(reporter->did_we_pass(), IsFalse());
+      });
+
+      it("reports a list of failures", [&](){
+        AssertThat(output(), Contains("List of failures:\n"));
+      });
+
+      it("reports the failed assertion", [&](){
+        AssertThat(output(), Contains("(*) context fails:\nsome_file:123: assertion failed!"));
+      });
+
+      it("only reports assertion failure once", [&](){
+        AssertThat(output(), Has().Exactly(1).EndingWith("assertion failed!"));
+      });
+    });
+
+    describe("a test run with a non assertion_exception thrown", [&](){
+      before_each([&](){
+        reporter->test_run_starting();
+        reporter->context_starting("context");
+        reporter->it_starting("throws an unknown exception");
+        reporter->it_unknown_error("throws an unknown exception");
+        reporter->context_ended("context");
+        reporter->test_run_complete();
+      });
+
+      it("shows the context summary", [&](){
+        AssertThat(output(), Contains("end context 1 total 1 failed"));
+      });
+
+      it("shows the unknown exception as error", [&](){
+        AssertThat(output(), Contains("-ERROR-> it throws"));
+      });
+
+      it("reports one failed test in the summary", [&](){
+        AssertThat(output(), Contains("Failed: 1"));
+      });
+
+      it("does not report passed tests in the summary", [&](){
+        AssertThat(output(), !Contains("Passed: "));
+      });
+
+      it("does not report skipped tests in the summary", [&](){
+        AssertThat(output(), !Contains("Skipped: "));
+      });
+
+      it("reports the failed test", [&](){
+        AssertThat(output(), Contains("(*) context throws an unknown exception: Unknown exception"))
+      });
+
+      it("does not end successfully", [&](){
+        AssertThat(reporter->did_we_pass(), IsFalse());
+      });
+    });
+
+    describe("a failing test run with nested contexts", [&](){
+      before_each([&](){
+        reporter->test_run_starting();
+        reporter->context_starting("context");
+        reporter->it_starting("passes");
+        reporter->it_succeeded("passes");
+        reporter->context_starting("nested context");
+        reporter->it_starting("fails");
+        bd::assertion_exception exception("assertion failed!", "some_file", 123);
+        reporter->it_failed("fails", exception);
+        reporter->context_ended("a nested context");
+        reporter->context_ended("my context");
+        reporter->test_run_complete();
+      });
+
+      it("shows the context", [&](){
+        AssertThat(output(), Contains("begin context\n"));
+        AssertThat(output(), Contains("\nend context 2 total 1 failed"));
+      });
+
+      it("shows the nested context", [&](){
+        AssertThat(output(), Contains("\n  begin nested context"));
+        AssertThat(output(), Contains("\n  end nested context 1 total 1 failed"));
+      });
+
+      it("shows the passing test as passed", [&](){
+        AssertThat(output(), Contains("  [ PASS ] it passes\n"));
+      });
+
+      it("shows the failing test as failed", [&](){
+        AssertThat(output(), Contains("    [ FAIL ] it fails\n"));
+      });
+
+      it("reports two run tests", [&](){
+        AssertThat(output(), Contains("Tests run: 2"));
+      });
+
+      it("reports one passed test in the summary", [&](){
+        AssertThat(output(), Contains("Passed: 1"));
+      });
+
+      it("reports one failed test in the summary", [&](){
+        AssertThat(output(), Contains("Failed: 1"));
+      });
+
+      it("does not report skipped tests in the summary", [&](){
+        AssertThat(output(), !Contains("Skipped: "));
+      });
+
+      it("reports the failed assertion", [&](){
+        AssertThat(output(), Contains("(*) context nested context fails:\nsome_file:123: assertion failed!"));
+      });
+
+      it("reports a failed test run", [&](){
+        AssertThat(reporter->did_we_pass(), IsFalse());
+      });
+    });
+
+    describe("a context with test run errors", [&](){
+      before_each([&](){
+        reporter->test_run_starting();
+        reporter->context_starting("context");
+        bd::test_run_error error("error!");
+        reporter->test_run_error("context", error);
+        reporter->context_ended("context");
+        reporter->test_run_complete();
+      });
+
+      it("reports a list of run errors", [&](){
+        AssertThat(output(), Contains("List of run errors:\n"));
+      });
+
+      it("reports that the context has failed", [&](){
+        AssertThat(output(), Contains(" (*) Failed to run \"context\": error \"error!\""));
+      });
+
+      it("reports no run tests in summary but one error", [&](){
+        AssertThat(output(), Contains("Tests run: 0\nErrors: 1"));
+      });
+
+      it("does not end succesful", [&](){
+        AssertThat(reporter->did_we_pass(), IsFalse());
+      });
+    });
+
+    describe("a context with a failing and a skipped test", [&](){
+      before_each([&](){
+        reporter->test_run_starting();
+        reporter->context_starting("context");
+        reporter->it_starting("fails");
+        bd::assertion_exception exception("assertion failed!", "some_file", 123);
+        reporter->it_failed("fails", exception);
+        reporter->it_skip("skips");
+        reporter->context_ended("context");
+        reporter->test_run_complete();
+      });
+
+      it("shows the failing test as failed", [&](){
+        AssertThat(output(), Contains("  [ FAIL ] it fails\n"));
+      });
+
+      it("does not show the skipped test", [&](){
+        AssertThat(output(), !Contains("[ SKIP ]"));
+      });
+
+      it("shows the skipped test in the context summary", [&](){
+        AssertThat(output(), Contains("end context 2 total 1 skipped 1 failed"));
+      });
+
+      it("does not report passed tests in the summary", [&](){
+        AssertThat(output(), !Contains("Passed: "));
+      });
+
+      it("reports one failed test in the summary", [&](){
+        AssertThat(output(), Contains("Failed: 1"));
+      });
+
+      it("reports one skipped test in the summary", [&](){
+        AssertThat(output(), Contains("Skipped: 1"));
+      });
+    });
+
+    describe("a context where all tests are skipped", [&](){
+      before_each([&](){
+        reporter->test_run_starting();
+        reporter->context_starting("context");
+        reporter->it_skip("skips first");
+        reporter->it_skip("skips second");
+        reporter->it_skip("skips last");
+        reporter->context_ended("context");
+        reporter->test_run_complete();
+      });
+
+      it("shows only the context", [&](){
+        AssertThat(output(), Contains("begin context\nend context 3 total 3 skipped"));
+      });
+
+      it("reports zero run tests in the summary", [&](){
+        AssertThat(output(), Contains("Tests run: 0"));
+      });
+
+      it("does not report passed tests in the summary", [&](){
+        AssertThat(output(), !Contains("Passed: "));
+      });
+
+      it("does not report failed tests in the summary", [&](){
+        AssertThat(output(), !Contains("Failed: "));
+      });
+
+      it("reports three skipped tests in the summary", [&](){
+        AssertThat(output(), Contains("Skipped: 3"));
+      });
+
+      it_skip("ends successfully", [&](){
+        AssertThat(reporter->did_we_pass(), IsTrue());
+      });
+    });
+
+    describe("a nested context where all tests are skipped", [&](){
+      before_each([&](){
+        reporter->test_run_starting();
+        reporter->context_starting("context");
+        reporter->context_starting("nested context");
+        reporter->context_starting("really nested context");
+        reporter->it_skip("skips first");
+        reporter->context_ended("really nested context");
+        reporter->it_skip("skips second");
+        reporter->context_ended("nested context");
+        reporter->it_skip("skips last");
+        reporter->it_starting("passes");
+        reporter->it_succeeded("passes");
+        reporter->context_ended("context");
+        reporter->test_run_complete();
+      });
+
+      it("shows only the passed test and not the nested contexts", [&](){
+        AssertThat(output(), Contains("begin context"));
+        AssertThat(output(), !Contains("nested context"));
+        AssertThat(output(), Contains("  [ PASS ] it passes\nend context 4 total 3 skipped"));
+      });
+
+      it("reports one run test in the summary", [&](){
+        AssertThat(output(), Contains("Tests run: 1"));
+      });
+
+      it("reports one passed test in the summary", [&](){
+        AssertThat(output(), Contains("Passed: 1"));
+      });
+
+      it("reports three skipped tests in the summary", [&](){
+        AssertThat(output(), Contains("Skipped: 3"));
+      });
+
+      it("ends successfully", [&](){
+        AssertThat(reporter->did_we_pass(), IsTrue());
+      });
+    });
+  });
+});

--- a/specs/reporters/info_reporter.spec.cpp
+++ b/specs/reporters/info_reporter.spec.cpp
@@ -25,7 +25,7 @@ go_bandit([](){
         AssertThat(output(), Equals("\nTests run: 0\n\n"));
       });
 
-      it_skip("is considered successful", [&](){
+      it("is considered successful", [&](){
         AssertThat(reporter->did_we_pass(), IsTrue());
       });
     });
@@ -329,7 +329,7 @@ go_bandit([](){
         AssertThat(output(), Contains("Skipped: 3"));
       });
 
-      it_skip("ends successfully", [&](){
+      it("ends successfully", [&](){
         AssertThat(reporter->did_we_pass(), IsTrue());
       });
     });


### PR DESCRIPTION
The info reporter in the original version contains various bugs (for example,
skipping can lead to crashes) and the reporter is not as fancy as it could be.

For example, the new info reporter gives summaries for each context
and omits showing nested contexts if they are skipped.

(Note that we are using this version of the info reporter for over two years now,
so I only cherry-picked the development commits.)

[WIP] because I am currently writing the long awaited tests for the reporter and this will lead
to some further behavior-changing commits. I only started the pull request
to allow a review of the non-WIP commits. (I am used to GitLab where [WIP]
makes the pull request unmergeable. I hope this works here, too.)