### PR TITLE
Option handling

### DIFF
--- a/bandit/options.h
+++ b/bandit/options.h
@@ -15,6 +15,8 @@ namespace bandit { namespace detail {
         std::vector<option::Option> buffer(stats.buffer_max);
         option::Parser parse(usage(), argc, argv, options_.data(), buffer.data());
         parsed_ok_ = !parse.error();
+        has_further_arguments_ = (parse.nonOptionsCount() != 0);
+        has_unknown_options_ = (options_[UNKNOWN] != nullptr);
       }
 
       bool help() const
@@ -25,6 +27,16 @@ namespace bandit { namespace detail {
       bool parsed_ok() const
       {
         return parsed_ok_;
+      }
+
+      bool has_further_arguments() const
+      {
+        return has_further_arguments_;
+      }
+
+      bool has_unknown_options() const
+      {
+        return has_unknown_options_;
       }
 
       void print_usage() const
@@ -113,6 +125,8 @@ namespace bandit { namespace detail {
       private:
         std::vector<option::Option> options_;
         bool parsed_ok_;
+        bool has_further_arguments_;
+        bool has_unknown_options_;
 
     };
 

--- a/bandit/options.h
+++ b/bandit/options.h
@@ -4,7 +4,6 @@
 namespace bandit { namespace detail {
 
     // TODO: print any unknown options
-    // TODO: check for parser errors
     struct options
     {
 
@@ -21,6 +20,11 @@ namespace bandit { namespace detail {
       bool help() const
       {
         return options_[HELP] != NULL;
+      }
+
+      bool parsed_ok() const
+      {
+        return parsed_ok_;
       }
 
       void print_usage() const

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -55,10 +55,10 @@ namespace bandit {
   inline int run(const detail::options& opt, const detail::spec_registry& specs,
       detail::contextstack_t& context_stack, detail::listener& listener)
   {
-    if(opt.help())
+    if(opt.help() || !opt.parsed_ok())
     {
       opt.print_usage();
-      return 0;
+      return !opt.parsed_ok();
     }
 
     if(opt.version())

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -84,9 +84,14 @@ namespace bandit {
     return listener.did_we_pass() ? 0 : 1;
   }
 
-  inline int run(int argc, char* argv[])
+  inline int run(int argc, char* argv[], int allow_further = true)
   {
     detail::options opt(argc, argv);
+    if (!allow_further &&
+        (opt.has_further_arguments() || opt.has_unknown_options())) {
+      opt.print_usage();
+      return 1;
+    }
     detail::failure_formatter_ptr formatter(create_formatter(opt));
     bandit::detail::colorizer colorizer(!opt.no_color());
     detail::listener_ptr reporter(create_reporter(opt, formatter.get(), colorizer));

--- a/specs/main.cpp
+++ b/specs/main.cpp
@@ -2,5 +2,5 @@
 
 int main(int argc, char* argv[])
 {
-  return bandit::run(argc, argv);
+  return bandit::run(argc, argv, false);
 }


### PR DESCRIPTION
This branch adds a check for parse errors to the runner and,
in case the test coder wants that, errors for unknown options
and further arguments.
