### PR TITLE
Make appveyor work again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ project(bandit)
 
 option(BANDIT_BUILD_SPECS   "Build the Bandit specs"                ON)
 option(BANDIT_RUN_SPECS     "Run the Bandit specs"                  ON)
-option(SNOWHOUSE_IS_CPP11   "Build Snowhouse with C++11 settings"   ON)
 
 set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(cotire/CMake/cotire)
@@ -46,8 +45,6 @@ if (BANDIT_BUILD_SPECS)
     set_target_properties(bandit-specs PROPERTIES COTIRE_ADD_UNIT_BUILD FALSE)
     cotire(bandit-specs)
 endif()
-
-add_subdirectory(bandit/assertion_frameworks/snowhouse)
 
 if (BANDIT_BUILD_SPECS AND BANDIT_RUN_SPECS)
     add_custom_command(TARGET bandit-specs

--- a/bandit/assertion_frameworks/matchers/must.h
+++ b/bandit/assertion_frameworks/matchers/must.h
@@ -30,7 +30,7 @@ namespace bandit { namespace Matchers
     }
 }}
 
-#define must	    ,(bandit::Matchers::ValueMarker){__FILE__, __LINE__},false,
-#define must_not    ,(bandit::Matchers::ValueMarker){__FILE__, __LINE__},true,
+#define must     ,bandit::Matchers::ValueMarker{__FILE__, __LINE__},false,
+#define must_not ,bandit::Matchers::ValueMarker{__FILE__, __LINE__},true,
 
 #endif	//BANDIT_MUST_H

--- a/specs/matchers/equal.cpp
+++ b/specs/matchers/equal.cpp
@@ -73,18 +73,19 @@ describe("when the actual value is a built-in type", []{
 });
 
 describe("when the actual value is declared as a C string", []{
-    char* actualValue = (char*)"actualValue";
+    char *actualValue = (char*)"actualValue";
+    const size_t len = strlen(actualValue);
 
     describe("and the expected value is declared as a C string", [&]{
 	std::unique_ptr<char> expectedValue;
 
 	before_each([&]{
-	    expectedValue.reset((char*)calloc(strlen(actualValue) + 1, sizeof(char)));
+	    expectedValue.reset((char*)calloc(len + 1, sizeof(char)));
 	});
 
 	describe("and the values are equal", [&]{
 	    before_each([&]{
-		stpcpy(expectedValue.get(), actualValue);
+		std::copy(actualValue, actualValue + len, expectedValue.get());
 	    });
 
 	    it("must accept a positive match", [&]{
@@ -98,7 +99,8 @@ describe("when the actual value is declared as a C string", []{
 
 	describe("and the values are not equal", [&]{
 	    before_each([&]{
-		stpcpy(expectedValue.get(), "expectedVal");
+		std::copy(actualValue, actualValue+len, expectedValue.get());
+		*(expectedValue.get()+1) = 'b'; // "abtualValue"
 	    });
 
 	    it("must accept a negative match", [&]{
@@ -133,12 +135,12 @@ describe("when the actual value is declared as a C string", []{
 	std::unique_ptr<char> expectedValue;
 
 	before_each([&]{
-	    expectedValue.reset((char*)calloc(strlen(actualValue) + 1, sizeof(char)));
+	    expectedValue.reset((char*)calloc(len + 1, sizeof(char)));
 	});
 
 	describe("and the values are equal", [&]{
 	    before_each([&]{
-		stpcpy(expectedValue.get(), actualValue);
+		std::copy(actualValue, actualValue + len, expectedValue.get());
 	    });
 
 	    it("must accept a positive match", [&]{
@@ -155,14 +157,15 @@ describe("when the actual value is declared as a C string", []{
 describe("when the actual value is a unique_ptr", []{
     std::unique_ptr<char> actualValue;
     auto expectedValue = (char*)"expectedValue";
+    const size_t len = strlen(expectedValue);
 
     before_each([&]{
-	actualValue.reset((char*)calloc(strlen(expectedValue) + 1, sizeof(char)));
+	actualValue.reset((char*)calloc(len + 1, sizeof(char)));
     });
 
     describe("when the strings are equal", [&]{
 	before_each([&]{
-	    stpcpy(actualValue.get(), expectedValue);
+	    std::copy(expectedValue, expectedValue + len, actualValue.get());
 	});
 
 	it("must accept a positive match", [&]{
@@ -172,7 +175,8 @@ describe("when the actual value is a unique_ptr", []{
 
     describe("when the strings are not equal", [&]{
 	before_each([&]{
-	    stpcpy(actualValue.get(), "hello");
+	    std::copy(expectedValue, expectedValue + len, actualValue.get());
+	    *(actualValue.get() + 4) = 'b'; // "expebtedValue"
 	});
 
 	it("must accept a negative match", [&]{

--- a/specs/matchers/throw_exception.cpp
+++ b/specs/matchers/throw_exception.cpp
@@ -35,16 +35,17 @@ describe("throw_exception", []{
 
     describe("with an exception class specified", [&]{
 	std::logic_error expected_exception("logic_error");
+	using exp_type = decltype(expected_exception);
 
         describe("when the block throws the expected exception", [&]{
 	    std::function<void()> exception_block = [&]{ throw expected_exception; };
 
 	    it("must pass a positive match", [&]{
-		exception_block must throw_exception.operator()<decltype(expected_exception)>();
+		exception_block must throw_exception.operator()<exp_type>();
 	    });
 
 	    it("must reject a negative match", [&]{
-		AssertThrows(std::exception, [&]{ exception_block must_not throw_exception.operator()<decltype(expected_exception)>(); }());
+		AssertThrows(std::exception, [&]{ exception_block must_not throw_exception.operator()<exp_type>(); }());
 	    });
         });
 
@@ -56,21 +57,21 @@ describe("throw_exception", []{
 
             describe("when subclasses are expected", [&]{
 		it("must pass a positive match", [&]{
-		    subclass_block must throw_exception.operator()<std::logic_error>().or_subclass();
+		    subclass_block must throw_exception.operator()<exp_type>().or_subclass();
 		});
 
 		it("must reject a negative match", [&]{
-		    AssertThrows(std::exception, [&]{ subclass_block must_not throw_exception.operator()<std::logic_error>().or_subclass(); }());
+		    AssertThrows(std::exception, [&]{ subclass_block must_not throw_exception.operator()<exp_type>().or_subclass(); }());
 		});
             });
 
             describe("when subclasses are not expected", [&]{
 		it("must pass a negative match", [&]{
-		    subclass_block must_not throw_exception.operator()<std::logic_error>();
+		    subclass_block must_not throw_exception.operator()<exp_type>();
 		});
 
 		it("must reject a positive match", [&]{
-		    AssertThrows(std::exception, [&]{ subclass_block must throw_exception.operator()<std::logic_error>(); }());
+		    AssertThrows(std::exception, [&]{ subclass_block must throw_exception.operator()<exp_type>(); }());
 		});
             });
         });
@@ -79,11 +80,11 @@ describe("throw_exception", []{
 	    std::function<void()> unrelated_block = [&]{ throw std::range_error("range error"); };
 
 	    it("must pass a negative match", [&]{
-		unrelated_block must_not throw_exception.operator()<decltype(expected_exception)>();
+		unrelated_block must_not throw_exception.operator()<exp_type>();
 	    });
 
 	    it("must reject a positive match", [&]{
-		AssertThrows(std::exception, [&]{ unrelated_block must throw_exception.operator()<decltype(expected_exception)>(); }());
+		AssertThrows(std::exception, [&]{ unrelated_block must throw_exception.operator()<exp_type>(); }());
 	    });
         });
 
@@ -91,11 +92,11 @@ describe("throw_exception", []{
 	    std::function<void()> quiet_block = [&]{};
 
 	    it("must pass a negative match", [&]{
-		quiet_block must_not throw_exception.operator()<decltype(expected_exception)>();
+		quiet_block must_not throw_exception.operator()<exp_type>();
 	    });
 
 	    it("must reject a positive match", [&]{
-		AssertThrows(std::exception, [&]{ quiet_block must throw_exception.operator()<decltype(expected_exception)>(); }());
+		AssertThrows(std::exception, [&]{ quiet_block must throw_exception.operator()<exp_type>(); }());
 	    });
         });
     });

--- a/specs/matchers/throw_exception.cpp
+++ b/specs/matchers/throw_exception.cpp
@@ -35,7 +35,7 @@ describe("throw_exception", []{
 
     describe("with an exception class specified", [&]{
 	std::logic_error expected_exception("logic_error");
-	using exp_type = decltype(expected_exception);
+	typedef decltype(expected_exception) exp_type;
 
         describe("when the block throws the expected exception", [&]{
 	    std::function<void()> exception_block = [&]{ throw expected_exception; };


### PR DESCRIPTION
These compatibility changes make bandit work with old versions
of Visual Studio (and gcc) such that appveyor is successful.