### PR TITLE
Remove matchers submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "bandit/assertion_frameworks/snowhouse"]
 	path = bandit/assertion_frameworks/snowhouse
 	url = https://github.com/banditcpp/snowhouse.git
-[submodule "bandit/assertion_frameworks/matchers"]
-	path = bandit/assertion_frameworks/matchers
-	url = https://github.com/banditcpp/matchers

--- a/bandit/bandit.h
+++ b/bandit/bandit.h
@@ -25,8 +25,6 @@ namespace bandit { namespace detail {
 #include <bandit/assertion_frameworks/snowhouse/snowhouse/snowhouse.h>
 using namespace snowhouse;
 
-#include <bandit/assertion_frameworks/matchers/matchers/matchers.h>
-
 #include <bandit/external/optionparser.h>
 #include <bandit/options.h>
 #include <bandit/test_run_error.h>


### PR DESCRIPTION
Matchers is currently unused in this repository, hence the
submodule and the inclusion of matchers.h is removed.

This is a compatibility-breaking change.

Users who want to use bandit with matchers now have to do
add something like

```c++
 #include <path_to_matchers/matchers/matchers.h>
 using namespace Matchers;
```

to their sources.