### PR TITLE
Change colorizer for Windows

### DIFF
--- a/bandit/reporters/colored_reporter.h
+++ b/bandit/reporters/colored_reporter.h
@@ -15,6 +15,11 @@ namespace bandit { namespace detail {
       : progress_reporter(failure_formatter), stm_(stm), colorizer_(colorizer)
     {}
 
+    virtual ~colored_reporter()
+    {
+      stm_ << colorizer_.reset();
+    }
+
   protected:
     std::ostream& stm_;
     const detail::colorizer& colorizer_;

--- a/bandit/reporters/colored_reporter.h
+++ b/bandit/reporters/colored_reporter.h
@@ -1,0 +1,25 @@
+#ifndef BANDIT_COLORED_REPORTER_H
+#define BANDIT_COLORED_REPORTER_H
+
+#include <ostream>
+#include <bandit/reporters/colorizer.h>
+#include <bandit/reporters/progress_reporter.h>
+
+namespace bandit { namespace detail {
+
+  struct colored_reporter : public progress_reporter
+  {
+    colored_reporter(std::ostream& stm,
+        const failure_formatter& failure_formatter,
+        const colorizer& colorizer)
+      : progress_reporter(failure_formatter), stm_(stm), colorizer_(colorizer)
+    {}
+
+  protected:
+    std::ostream& stm_;
+    const detail::colorizer& colorizer_;
+  };
+
+}}
+
+#endif

--- a/bandit/reporters/colorizer.h
+++ b/bandit/reporters/colorizer.h
@@ -19,14 +19,15 @@ namespace bandit { namespace detail {
       : colors_enabled_(colors_enabled),
 		stdout_handle_(GetStdHandle(STD_OUTPUT_HANDLE))
     {
-		original_color_ = get_console_color();
+		background_color_ = original_color_ = get_console_color();
+		background_color_ &= BACKGROUND_BLUE | BACKGROUND_GREEN | BACKGROUND_RED | BACKGROUND_INTENSITY;
 	}
 
     const char* green() const
     {
       if(colors_enabled_)
 	  {
-		  set_console_color(FOREGROUND_GREEN);
+		  set_console_color(FOREGROUND_GREEN | background_color_);
 	  }
 	  return "";
     }
@@ -35,7 +36,7 @@ namespace bandit { namespace detail {
     {
       if(colors_enabled_)
 	  {
-		  set_console_color(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY);
+		  set_console_color(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY | background_color_);
 	  }
 	  return "";
     }
@@ -44,7 +45,7 @@ namespace bandit { namespace detail {
     {
       if(colors_enabled_)
 	  {
-		  set_console_color(FOREGROUND_BLUE);
+		  set_console_color(FOREGROUND_BLUE | background_color_);
 	  }
 	  return "";
     }
@@ -53,7 +54,7 @@ namespace bandit { namespace detail {
     {
       if(colors_enabled_)
 	  {
-		  set_console_color(FOREGROUND_RED);
+		  set_console_color(FOREGROUND_RED | background_color_);
 	  }
 	  return "";
     }
@@ -62,7 +63,7 @@ namespace bandit { namespace detail {
     {
       if(colors_enabled_)
 	  {
-		  set_console_color(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY);
+		  set_console_color(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY | background_color_);
 	  }
 	  return "";
     }
@@ -93,6 +94,7 @@ namespace bandit { namespace detail {
     bool colors_enabled_;
 	HANDLE stdout_handle_;
 	WORD original_color_;
+	WORD background_color_;
   };
 
 #else

--- a/bandit/reporters/colorizer.h
+++ b/bandit/reporters/colorizer.h
@@ -27,7 +27,7 @@ namespace bandit { namespace detail {
     {
       if(colors_enabled_)
 	  {
-		  set_console_color(FOREGROUND_GREEN | background_color_);
+		  set_console_color(FOREGROUND_GREEN | FOREGROUND_INTENSITY | background_color_);
 	  }
 	  return "";
     }
@@ -45,7 +45,7 @@ namespace bandit { namespace detail {
     {
       if(colors_enabled_)
 	  {
-		  set_console_color(FOREGROUND_BLUE | background_color_);
+		  set_console_color(FOREGROUND_BLUE | FOREGROUND_INTENSITY | background_color_);
 	  }
 	  return "";
     }
@@ -54,7 +54,7 @@ namespace bandit { namespace detail {
     {
       if(colors_enabled_)
 	  {
-		  set_console_color(FOREGROUND_RED | background_color_);
+		  set_console_color(FOREGROUND_RED | FOREGROUND_INTENSITY | background_color_);
 	  }
 	  return "";
     }

--- a/bandit/reporters/dots_reporter.h
+++ b/bandit/reporters/dots_reporter.h
@@ -1,16 +1,16 @@
 #ifndef BANDIT_DOTS_REPORTER_H
 #define BANDIT_DOTS_REPORTER_H
 
-#include <bandit/reporters/progress_reporter.h>
+#include <bandit/reporters/colored_reporter.h>
 #include <bandit/reporters/test_run_summary.h>
 
 namespace bandit { namespace detail {
 
-  struct dots_reporter : public progress_reporter
+  struct dots_reporter : public colored_reporter
   {
-    dots_reporter(std::ostream& stm, const failure_formatter& failure_formatter, 
-        const detail::colorizer& colorizer)
-      : progress_reporter(failure_formatter), stm_(stm), colorizer_(colorizer)
+    dots_reporter(std::ostream& stm, const failure_formatter& failure_formatter,
+        const colorizer& colorizer)
+      : colored_reporter(stm, failure_formatter, colorizer)
     {}
 
     dots_reporter(const failure_formatter& failure_formatter, const colorizer& colorizer)
@@ -69,10 +69,6 @@ namespace bandit { namespace detail {
       stm_ << colorizer_.red() << "E" << colorizer_.reset();
       stm_.flush();
     }
-
-    private:
-    std::ostream& stm_;
-    const detail::colorizer& colorizer_;
   };
 }}
 

--- a/bandit/reporters/info_reporter.h
+++ b/bandit/reporters/info_reporter.h
@@ -2,13 +2,13 @@
 #define BANDIT_INFO_REPORTER_H
 
 #include <stack>
-#include <bandit/reporters/progress_reporter.h>
+#include <bandit/reporters/colored_reporter.h>
 #include <bandit/reporters/test_run_summary.h>
 
 namespace bandit {
 namespace detail {
 
-struct info_reporter : public progress_reporter
+struct info_reporter : public colored_reporter
 {
 	struct context_info
 	{
@@ -25,10 +25,8 @@ struct info_reporter : public progress_reporter
 		int failed;
 	};
 
-	info_reporter(std::ostream &stm, const failure_formatter &failure_formatter, const detail::colorizer &colorizer)
-	  : progress_reporter(failure_formatter)
-	  , stm_(stm)
-	  , colorizer_(colorizer)
+	info_reporter(std::ostream &stm, const failure_formatter &failure_formatter, const colorizer &colorizer)
+	  : colored_reporter(stm, failure_formatter, colorizer)
 	  , indentation_(0)
 	  , not_yet_shown_(0)
 	  , context_stack_()
@@ -306,8 +304,6 @@ private:
 		return std::string(2*indentation_, ' ');
 	}
 
-	std::ostream &stm_;
-	const detail::colorizer &colorizer_;
 	int indentation_;
 	int not_yet_shown_; // number of elements in stack that are not yet shown
 	std::stack<context_info> context_stack_;

--- a/bandit/reporters/single_line_reporter.h
+++ b/bandit/reporters/single_line_reporter.h
@@ -1,16 +1,16 @@
 #ifndef BANDIT_REPORTERS_SINGLE_LINE_REPORTER_H
 #define BANDIT_REPORTERS_SINGLE_LINE_REPORTER_H
 
-#include <bandit/reporters/progress_reporter.h>
+#include <bandit/reporters/colored_reporter.h>
 #include <bandit/reporters/test_run_summary.h>
 
 namespace bandit { namespace detail {
 
-  struct single_line_reporter : public progress_reporter
+  struct single_line_reporter : public colored_reporter
   {
     single_line_reporter(std::ostream& stm, const failure_formatter& failure_formatter,
-        const detail::colorizer& colorizer)
-      : progress_reporter(failure_formatter), stm_(stm), colorizer_(colorizer)
+        const colorizer& colorizer)
+      : colored_reporter(stm, failure_formatter, colorizer)
     {}
 
     single_line_reporter(const failure_formatter& failure_formatter,
@@ -79,10 +79,6 @@ namespace bandit { namespace detail {
       }
       stm_.flush();
     }
-
-    private:
-    std::ostream& stm_;
-    const detail::colorizer& colorizer_;
   };
 }}
 

--- a/bandit/reporters/spec_reporter.h
+++ b/bandit/reporters/spec_reporter.h
@@ -1,16 +1,17 @@
 #ifndef BANDIT_SPEC_REPORTER_H
 #define BANDIT_SPEC_REPORTER_H
 
-#include <bandit/reporters/progress_reporter.h>
+#include <bandit/reporters/colored_reporter.h>
 #include <bandit/reporters/test_run_summary.h>
 
 namespace bandit { namespace detail {
 
-  struct spec_reporter : public progress_reporter
+  struct spec_reporter : public colored_reporter
   {
     spec_reporter(std::ostream& stm, const failure_formatter& failure_formatter, 
-        const detail::colorizer& colorizer)
-      : progress_reporter(failure_formatter),  stm_(stm), colorizer_(colorizer), indentation_(0)
+        const colorizer& colorizer)
+      : colored_reporter(stm, failure_formatter, colorizer)
+      , indentation_(0)
     {}
 
     spec_reporter(const failure_formatter& failure_formatter, const colorizer& colorizer)
@@ -119,9 +120,7 @@ namespace bandit { namespace detail {
       return std::string(indentation_, '\t');
     }
 
-    private:
-    std::ostream& stm_;
-    const detail::colorizer& colorizer_;
+  private:
     int indentation_;
   };
 }}

--- a/specs/reporters/dots_reporter.spec.cpp
+++ b/specs/reporters/dots_reporter.spec.cpp
@@ -4,18 +4,18 @@ namespace bd = bandit::detail;
 go_bandit([](){
 
   describe("dots_reporter:", [&](){
-    std::unique_ptr<std::stringstream> stm;
+    std::stringstream stm;
     std::unique_ptr<bd::dots_reporter> reporter;
     bd::default_failure_formatter formatter;
     bd::colorizer colorizer(false);
   
     before_each([&](){
-      stm = std::unique_ptr<std::stringstream>(new std::stringstream());
+      stm.str(std::string());
       reporter = std::unique_ptr<bd::dots_reporter>(
-        new bd::dots_reporter(*stm, formatter, colorizer));
+        new bd::dots_reporter(stm, formatter, colorizer));
     });
 
-    auto output = [&](){ return stm->str(); };
+    auto output = [&](){ return stm.str(); };
 
     describe("an empty test run", [&](){
     

--- a/specs/reporters/info_reporter.spec.cpp
+++ b/specs/reporters/info_reporter.spec.cpp
@@ -3,17 +3,17 @@ namespace bd = bandit::detail;
 
 go_bandit([](){
   describe("info_reporter:", [&](){
-    std::unique_ptr<std::stringstream> stm;
+    std::stringstream stm;
     std::unique_ptr<bd::info_reporter> reporter;
     bd::default_failure_formatter formatter;
     bd::colorizer colorizer(false);
 
     before_each([&](){
-      stm = std::unique_ptr<std::stringstream>(new std::stringstream());
-      reporter = std::unique_ptr<bd::info_reporter>(new bd::info_reporter(*stm, formatter, colorizer));
+      stm.str(std::string());
+      reporter = std::unique_ptr<bd::info_reporter>(new bd::info_reporter(stm, formatter, colorizer));
     });
 
-    auto output = [&](){ return stm->str(); };
+    auto output = [&](){ return stm.str(); };
 
     describe("an empty test run", [&](){
       before_each([&](){

--- a/specs/reporters/single_line_reporter.spec.cpp
+++ b/specs/reporters/single_line_reporter.spec.cpp
@@ -4,18 +4,18 @@ namespace bd = bandit::detail;
 go_bandit([](){
 
   describe("single line reporter", [&](){
-    std::unique_ptr<std::stringstream> stm;
+    std::stringstream stm;
     std::unique_ptr<bd::single_line_reporter> reporter;
     bd::default_failure_formatter formatter;
     bd::colorizer colorizer(false);
   
     before_each([&](){
-      stm = std::unique_ptr<std::stringstream>(new std::stringstream());
+      stm.str(std::string());
       reporter = std::unique_ptr<bd::single_line_reporter>(
-        new bd::single_line_reporter(*stm, formatter, colorizer));
+        new bd::single_line_reporter(stm, formatter, colorizer));
     });
 
-    auto output = [&](){ return stm->str(); };
+    auto output = [&](){ return stm.str(); };
   
    describe("an empty test run", [&](){
    

--- a/specs/reporters/xunit_reporter.spec.cpp
+++ b/specs/reporters/xunit_reporter.spec.cpp
@@ -4,15 +4,15 @@ namespace bd = bandit::detail;
 go_bandit([](){
 
   describe("xunit_reporter:", [&](){
-    std::unique_ptr<std::stringstream> stm;
+    std::stringstream stm;
     bd::default_failure_formatter formatter;
     std::unique_ptr<bd::xunit_reporter> reporter;
 
-    auto output = [&](){ return stm->str(); };
+    auto output = [&](){ return stm.str(); };
 
     before_each([&](){
-      stm = std::unique_ptr<std::stringstream>(new std::stringstream());
-      reporter = std::unique_ptr<bd::xunit_reporter>(new bd::xunit_reporter(*stm, formatter));
+      stm.str(std::string());
+      reporter = std::unique_ptr<bd::xunit_reporter>(new bd::xunit_reporter(stm, formatter));
     });
 
     describe("an empty test run", [&](){


### PR DESCRIPTION
The colorizer for Windows is changed that it
* does not change the background color and
* has intense colors

Additionally, reporters with colors now always reset
the colorizer on destruction (regardless of the operating
system).

This is related to #90.