### PR TITLE
Improve option handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ include_directories("${PROJECT_SOURCE_DIR}")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ./bin)
 
 if (MSVC)
+  add_definitions(-D_SCL_SECURE_NO_WARNINGS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /MP ")
 else()
   # Assume GCC-style arguments

--- a/bandit/options.h
+++ b/bandit/options.h
@@ -83,7 +83,7 @@ namespace bandit { namespace detail {
 
       bool help() const
       {
-        return options_[HELP] != NULL;
+        return options_[HELP] != nullptr;
       }
 
       void print_usage() const
@@ -93,7 +93,7 @@ namespace bandit { namespace detail {
 
       bool version() const
       {
-        return options_[VERSION] != NULL;
+        return options_[VERSION] != nullptr;
       }
 
       const char* reporter() const
@@ -103,7 +103,7 @@ namespace bandit { namespace detail {
 
       bool no_color() const
       {
-        return options_[NO_COLOR] != NULL;
+        return options_[NO_COLOR] != nullptr;
       }
 
       typedef enum
@@ -136,12 +136,12 @@ namespace bandit { namespace detail {
 
       bool break_on_failure() const
       {
-          return options_[BREAK_ON_FAILURE] != NULL;
+        return options_[BREAK_ON_FAILURE] != nullptr;
       }
 
       bool dry_run() const
       {
-          return options_[DRY_RUN] != NULL;
+        return options_[DRY_RUN] != nullptr;
       }
 
     private:

--- a/bandit/options.h
+++ b/bandit/options.h
@@ -9,7 +9,6 @@
 
 namespace bandit { namespace detail {
 
-    // TODO: print any unknown options
     struct options
     {
       template<typename ENUM>

--- a/bandit/options.h
+++ b/bandit/options.h
@@ -45,13 +45,19 @@ namespace bandit { namespace detail {
           return csl;
         }
 
+        static std::string name(const option::Option& option)
+        {
+          std::string copy(option.name);
+          return copy.substr(0, option.namelen);
+        }
+
         static option::ArgStatus Required(const option::Option& option, bool msg)
         {
           if (option.arg != nullptr) {
             return option::ARG_OK;
           }
           if (msg) {
-            std::cerr << "Option '" << option.name << "' requires an argument\n";
+            std::cerr << "Option '" << name(option) << "' requires an argument\n";
           }
           return option::ARG_ILLEGAL;
         }
@@ -63,7 +69,7 @@ namespace bandit { namespace detail {
            && std::find(list.begin(), list.end(), option.arg) == list.end()) {
             if (msg) {
               std::cerr
-                << "Option argument of '" << option.name << "' must be one of: "
+                << "Option argument of '" << name(option) << "' must be one of: "
                 << comma_separated_list(list)
                 << std::endl;
             }

--- a/bandit/options.h
+++ b/bandit/options.h
@@ -1,6 +1,7 @@
 #ifndef BANDIT_OPTIONS_H
 #define BANDIT_OPTIONS_H
 
+#include <algorithm>
 #include <vector>
 #include <iostream>
 
@@ -12,6 +13,63 @@ namespace bandit { namespace detail {
     // TODO: check for parser errors
     struct options
     {
+      struct argument : public option::Arg {
+        static const std::vector<std::string> reporter_list()
+        {
+          return {
+            "dots",
+            "singleline",
+            "xunit",
+            "info",
+            "spec",
+          };
+        }
+
+        static const std::vector<std::string> formatter_list()
+        {
+          return {
+            "default",
+            "vs",
+          };
+        }
+
+        static option::ArgStatus Required(const option::Option& option, bool msg)
+        {
+          if (option.arg != nullptr) {
+            return option::ARG_OK;
+          }
+          if (msg) {
+            std::cerr << "Option '" << option.name << "' requires an argument\n";
+          }
+          return option::ARG_ILLEGAL;
+        }
+
+        static option::ArgStatus OneOf(const option::Option& option, bool msg, const std::vector<std::string> &&list)
+        {
+          auto status = Required(option, msg);
+          if (status == option::ARG_OK
+           && std::find(list.begin(), list.end(), option.arg) == list.end()) {
+            if (msg) {
+              std::cerr << "Option argument of '" << option.name << "' must be one of:\n";
+              for (auto item : list) {
+                std::cerr << " * " << item << std::endl;
+              }
+            }
+            status = option::ARG_ILLEGAL;
+          }
+          return status;
+        }
+
+        static option::ArgStatus Reporter(const option::Option& option, bool msg)
+        {
+          return OneOf(option, msg, reporter_list());
+        }
+
+        static option::ArgStatus Formatter(const option::Option& option, bool msg)
+        {
+          return OneOf(option, msg, formatter_list());
+        }
+      };
 
       options(int argc, char* argv[])
       {
@@ -86,34 +144,54 @@ namespace bandit { namespace detail {
           return options_[DRY_RUN] != NULL;
       }
 
-      private:
-        enum option_index { UNKNOWN, VERSION, HELP, REPORTER, NO_COLOR,
-          FORMATTER, SKIP, ONLY, BREAK_ON_FAILURE, DRY_RUN };
+    private:
+      enum option_index {
+        UNKNOWN,
+        VERSION,
+        HELP,
+        REPORTER,
+        NO_COLOR,
+        FORMATTER,
+        SKIP,
+        ONLY,
+        BREAK_ON_FAILURE,
+        DRY_RUN,
+      };
 
-        static const option::Descriptor* usage()
-        {
-          static const option::Descriptor usage[] =
-          {
-            {UNKNOWN, 0, "", "", option::Arg::None,         "USAGE: <executable> [options]\n\n"
-                                                            "Options:" },
-            {VERSION, 0, "", "version", option::Arg::None, "  --version, \tPrint version of bandit"},
-            {HELP, 0, "", "help", option::Arg::None,        "  --help, \tPrint usage and exit."},
-            {REPORTER, 0, "", "reporter", option::Arg::Optional, "  --reporter=<reporter>, \tSelect reporter (dots, singleline, xunit, info, spec)"},
-            {NO_COLOR, 0, "", "no-color", option::Arg::None,     "  --no-color, \tSuppress colors in output"},
-            {FORMATTER, 0, "", "formatter", option::Arg::Optional, "  --formatter=<formatter>, \tSelect formatting of errors (default, vs)"},
-            {SKIP, 0, "", "skip", option::Arg::Optional, "  --skip=<substring>, \tskip all 'describe' and 'it' containing substring"},
-            {ONLY, 0, "", "only", option::Arg::Optional, "  --only=<substring>, \tonly run 'describe' and 'it' containing substring"},
-            {BREAK_ON_FAILURE, 0, "", "break-on-failure", option::Arg::Optional, "  --break-on-failure, \tstop test run on first failing test"},
-            {DRY_RUN, 0, "", "dry-run", option::Arg::Optional, "  --dry-run, \tdon't run tests. Just list progress. Use to list available tests"},
-            {0, 0, 0, 0, 0, 0}
-          };
+      static const option::Descriptor* usage()
+      {
+        static const option::Descriptor usage[] = {
+          { UNKNOWN, 0, "", "", argument::None,
+            "USAGE: <executable> [options]\n\n"
+            "Options:" },
+          { VERSION, 0, "", "version", argument::None,
+            "  --version, \tPrint version of bandit" },
+          { HELP, 0, "", "help", argument::None,
+            "  --help, \tPrint usage and exit." },
+          { REPORTER, 0, "", "reporter", argument::Reporter,
+            "  --reporter=<reporter>, \tSelect reporter" },
+          { NO_COLOR, 0, "", "no-color", argument::None,
+            "  --no-color, \tSuppress colors in output" },
+          { FORMATTER, 0, "", "formatter", argument::Formatter,
+            "  --formatter=<formatter>, \tSelect formatting of errors" },
+          { SKIP, 0, "", "skip", argument::Required,
+            "  --skip=<substring>, \tskip all 'describe' and 'it' containing substring" },
+          { ONLY, 0, "", "only", argument::Required,
+            "  --only=<substring>, \tonly run 'describe' and 'it' containing substring" },
+          { BREAK_ON_FAILURE, 0, "", "break-on-failure", argument::None,
+            "  --break-on-failure, \tstop test run on first failing test" },
+          { DRY_RUN, 0, "", "dry-run", argument::None,
+            "  --dry-run, \tdon't run tests, just list progress."
+            "Use to list available tests" },
+          { 0, 0, 0, 0, 0, 0 }
+        };
 
-          return usage;
-        }
+        return usage;
+      }
 
-      private:
-        std::vector<option::Option> options_;
-        bool parsed_ok_;
+    private:
+      std::vector<option::Option> options_;
+      bool parsed_ok_;
 
     };
 

--- a/bandit/options.h
+++ b/bandit/options.h
@@ -63,15 +63,24 @@ namespace bandit { namespace detail {
         UNKNOWN
       };
 
+      enum class reporters {
+        SINGLELINE,
+        XUNIT,
+        INFO,
+        SPEC,
+        DOTS,
+        UNKNOWN
+      };
+
       struct argument : public option::Arg {
-        static const argstrs<nullptr_t> reporter_list()
+        static const argstrs<reporters> reporter_list()
         {
           return {
-            { nullptr, "dots" },
-            { nullptr, "singleline" },
-            { nullptr, "xunit" },
-            { nullptr, "info" },
-            { nullptr, "spec" },
+            { reporters::DOTS, "dots" },
+            { reporters::SINGLELINE, "singleline" },
+            { reporters::XUNIT, "xunit" },
+            { reporters::INFO, "info" },
+            { reporters::SPEC, "spec" },
           };
         }
 
@@ -183,9 +192,16 @@ namespace bandit { namespace detail {
         return options_[VERSION] != nullptr;
       }
 
-      const char* reporter() const
+      reporters reporter() const
       {
-        return options_[REPORTER].arg;
+        const auto list(argument::reporter_list());
+        if (options_[REPORTER].arg != nullptr) {
+          auto it = std::find(list.strbegin(), list.strend(), options_[REPORTER].arg);
+          if (it != list.strend()) {
+            return it.id();
+          }
+        }
+        return reporters::UNKNOWN;
       }
 
       bool no_color() const

--- a/bandit/options.h
+++ b/bandit/options.h
@@ -194,14 +194,7 @@ namespace bandit { namespace detail {
 
       reporters reporter() const
       {
-        const auto list(argument::reporter_list());
-        if (options_[REPORTER].arg != nullptr) {
-          auto it = std::find(list.strbegin(), list.strend(), options_[REPORTER].arg);
-          if (it != list.strend()) {
-            return it.id();
-          }
-        }
-        return reporters::UNKNOWN;
+        return get_enumerator_from_string(argument::reporter_list(), options_[REPORTER].arg);
       }
 
       bool no_color() const
@@ -211,14 +204,7 @@ namespace bandit { namespace detail {
 
       formatters formatter() const
       {
-        const auto list(argument::formatter_list());
-        if (options_[FORMATTER].arg != nullptr) {
-          auto it = std::find(list.strbegin(), list.strend(), options_[FORMATTER].arg);
-          if (it != list.strend()) {
-            return it.id();
-          }
-        }
-        return formatters::DEFAULT;
+        return get_enumerator_from_string(argument::formatter_list(), options_[FORMATTER].arg);
       }
 
       const char* skip() const
@@ -242,6 +228,18 @@ namespace bandit { namespace detail {
       }
 
     private:
+      template<typename ENUM>
+      ENUM get_enumerator_from_string(const argstrs<ENUM> &list, const char *str) const
+      {
+        if (str != nullptr) {
+          auto it = std::find(list.strbegin(), list.strend(), str);
+          if (it != list.strend()) {
+            return it.id();
+          }
+        }
+        return ENUM::UNKNOWN;
+      }
+
       enum option_index {
         UNKNOWN,
         VERSION,

--- a/bandit/options.h
+++ b/bandit/options.h
@@ -140,22 +140,21 @@ namespace bandit { namespace detail {
         return options_[NO_COLOR] != nullptr;
       }
 
-      typedef enum
-      {
-        FORMATTER_DEFAULT,
-        FORMATTER_VS,
-        FORMATTER_UNKNOWN
-      } formatters;
+      enum class formatters {
+        DEFAULT,
+        VS,
+        UNKNOWN
+      };
 
       formatters formatter() const
       {
         std::string arg = options_[FORMATTER].arg ? options_[FORMATTER].arg : "";
         if(arg == "vs")
         {
-          return formatters::FORMATTER_VS;
+          return formatters::VS;
         }
 
-        return formatters::FORMATTER_DEFAULT;
+        return formatters::DEFAULT;
       }
 
       const char* skip() const

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -20,29 +20,19 @@ namespace bandit {
     inline listener_ptr create_reporter(const options& opt,
         const failure_formatter* formatter, const colorizer& colorizer)
     {
-      std::string name(opt.reporter() ? opt.reporter() : "");
-
-      if(name == "singleline")
-      {
-        return std::unique_ptr<detail::listener>(new single_line_reporter(*formatter, colorizer));
+      switch (opt.reporter()) {
+      case options::reporters::SINGLELINE:
+        return listener_ptr(new single_line_reporter(*formatter, colorizer));
+      case options::reporters::XUNIT:
+        return listener_ptr(new xunit_reporter(*formatter));
+      case options::reporters::INFO:
+        return listener_ptr(new info_reporter(*formatter, colorizer));
+      case options::reporters::SPEC:
+        return listener_ptr(new spec_reporter(*formatter, colorizer));
+      case options::reporters::DOTS:
+      default:
+        return listener_ptr(new dots_reporter(*formatter, colorizer));
       }
-
-      if(name == "xunit")
-      {
-        return std::unique_ptr<detail::listener>(new xunit_reporter(*formatter));
-      }
-
-      if(name == "info")
-      {
-        return std::unique_ptr<detail::listener>(new info_reporter(*formatter, colorizer));
-      }
-
-      if(name == "spec")
-      {
-        return std::unique_ptr<detail::listener>(new spec_reporter(*formatter, colorizer));
-      }
-
-      return std::unique_ptr<detail::listener>(new dots_reporter(*formatter, colorizer));
     }
 
     typedef std::function<listener_ptr (const std::string&, const failure_formatter*)> reporter_factory_fn;
@@ -50,12 +40,13 @@ namespace bandit {
 
     inline failure_formatter_ptr create_formatter(const options& opt)
     {
-      if(opt.formatter() == options::formatters::VS)
-      {
+      switch (opt.formatter()) {
+      case options::formatters::VS:
         return failure_formatter_ptr(new visual_studio_failure_formatter());
+      case options::formatters::DEFAULT:
+      default:
+        return failure_formatter_ptr(new default_failure_formatter());
       }
-
-      return failure_formatter_ptr(new default_failure_formatter());
     }
   }
 

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -50,7 +50,7 @@ namespace bandit {
 
     inline failure_formatter_ptr create_formatter(const options& opt)
     {
-      if(opt.formatter() == options::formatters::FORMATTER_VS)
+      if(opt.formatter() == options::formatters::VS)
       {
         return failure_formatter_ptr(new visual_studio_failure_formatter());
       }

--- a/specs/before_each_after_each.spec.cpp
+++ b/specs/before_each_after_each.spec.cpp
@@ -1,3 +1,4 @@
+#include <specs/fakes/fake_context.h>
 #include <specs/specs.h>
 
 namespace bf = bandit::fakes;

--- a/specs/describe.spec.cpp
+++ b/specs/describe.spec.cpp
@@ -1,3 +1,5 @@
+#include <specs/fakes/fake_context.h>
+#include <specs/fakes/fake_reporter.h>
 #include <specs/specs.h>
 
 using namespace bandit::fakes;

--- a/specs/fakes/fake_context.h
+++ b/specs/fakes/fake_context.h
@@ -1,6 +1,9 @@
 #ifndef BANDIT_FAKE_CONTEXT_H
 #define BANDIT_FAKE_CONTEXT_H
 
+#include <bandit/bandit.h>
+#include <specs/fakes/logging_fake.h>
+
 namespace bandit { namespace fakes {
 
   struct fake_context : public bandit::detail::context, public bandit::specs::logging_fake

--- a/specs/fakes/fake_reporter.h
+++ b/specs/fakes/fake_reporter.h
@@ -1,6 +1,9 @@
 #ifndef BANDIT_SPECS_FAKE_REPORTER_H
 #define BANDIT_SPECS_FAKE_REPORTER_H
 
+#include <bandit/bandit.h>
+#include <specs/fakes/logging_fake.h>
+
 namespace bandit { namespace fakes {
   struct fake_reporter : 
     public bandit::detail::listener, 

--- a/specs/fakes/fakes.h
+++ b/specs/fakes/fakes.h
@@ -1,8 +1,0 @@
-#ifndef BANDIT_SPECS_FAKES_H
-#define BANDIT_SPECS_FAKES_H
-
-#include <specs/fakes/logging_fake.h>
-#include <specs/fakes/fake_reporter.h>
-#include <specs/fakes/fake_context.h>
-
-#endif

--- a/specs/fakes/logging_fake.h
+++ b/specs/fakes/logging_fake.h
@@ -1,5 +1,7 @@
 #ifndef BANDIT_SPECS_LOGGING_FAKE_H
 #define BANDIT_SPECS_LOGGING_FAKE_H
+
+#include <algorithm>
 #include <sstream>
 
 namespace bandit { namespace specs {

--- a/specs/it.spec.cpp
+++ b/specs/it.spec.cpp
@@ -1,4 +1,7 @@
+#include <specs/fakes/fake_context.h>
+#include <specs/fakes/fake_reporter.h>
 #include <specs/specs.h>
+
 using namespace bandit::fakes;
 namespace bd = bandit::detail;
 

--- a/specs/options.spec.cpp
+++ b/specs/options.spec.cpp
@@ -15,8 +15,7 @@ go_bandit([](){
     describe("options:", [&](){
 
       it("parses the '--help' option", [&](){
-        const char* args[] = {"executable", "--help"};
-        argv_helper argv(2, args);
+        argv_helper argv({"executable", "--help"});
 
         bd::options opt(argv.argc(), argv.argv());
 
@@ -25,8 +24,7 @@ go_bandit([](){
       });
 
       it("parses the '--version' option", [&](){
-        const char* args[] = {"executable", "--version"};
-        argv_helper argv(2, args);
+        argv_helper argv({"executable", "--version"});
 
         bd::options opt(argv.argc(), argv.argv());
 
@@ -35,8 +33,7 @@ go_bandit([](){
       });
 
       it("parses the '--no-color' option", [&](){
-        const char* args[] = {"executable", "--no-color"};
-        argv_helper argv(2, args);
+        argv_helper argv({"executable", "--no-color"});
 
         bd::options opt(argv.argc(), argv.argv());
 
@@ -44,18 +41,16 @@ go_bandit([](){
         all_ok(opt);
       });
 
-      it("parser the '--formatter=vs' option", [&](){
-        const char* args[] = {"executable", "--formatter=vs"};
-        argv_helper argv(2, args);
+      it("parses the '--formatter=vs' option", [&](){
+        argv_helper argv({"executable", "--formatter=vs"});
 
         bd::options opt(argv.argc(), argv.argv());
         AssertThat(opt.formatter(), Equals(bd::options::formatters::FORMATTER_VS));
         all_ok(opt);
       });
 
-      it("parser the '--formatter=default' option", [&](){
-        const char* args[] = {"executable", "--formatter=default"};
-        argv_helper argv(2, args);
+      it("parses the '--formatter=default' option", [&](){
+        argv_helper argv({"executable", "--formatter=default"});
 
         bd::options opt(argv.argc(), argv.argv());
         AssertThat(opt.formatter(), Equals(bd::options::formatters::FORMATTER_DEFAULT));
@@ -63,8 +58,7 @@ go_bandit([](){
       });
 
       it("parses the '--skip=\"substring\"' option", [&](){
-        const char* args[] = {"executable", "--skip=substring"};
-        argv_helper argv(2, args);
+        argv_helper argv({"executable", "--skip=substring"});
 
         bd::options opt(argv.argc(), argv.argv());
         AssertThat(opt.skip(), Equals("substring"));
@@ -72,8 +66,7 @@ go_bandit([](){
       });
 
       it("parses skip as empty string if not present", [&](){
-        const char* args[] = {"executable"};
-        argv_helper argv(1, args);
+        argv_helper argv({"executable"});
 
         bd::options opt(argv.argc(), argv.argv());
         AssertThat(opt.skip(), Equals(""));
@@ -81,8 +74,7 @@ go_bandit([](){
       });
 
       it("parses the '--only=\"substring\"' option", [&](){
-        const char* args[] = {"executable", "--only=substring"};
-        argv_helper argv(2, args);
+        argv_helper argv({"executable", "--only=substring"});
 
         bd::options opt(argv.argc(), argv.argv());
         AssertThat(opt.only(), Equals("substring"));
@@ -90,8 +82,7 @@ go_bandit([](){
       });
 
       it("parses only as empty string if not present", [&](){
-        const char* args[] = {"executable"};
-        argv_helper argv(1, args);
+        argv_helper argv({"executable"});
 
         bd::options opt(argv.argc(), argv.argv());
         AssertThat(opt.only(), Equals(""));
@@ -99,8 +90,7 @@ go_bandit([](){
       });
 
       it("parses the '--break-on-failure' option", [&](){
-        const char* args[] = {"executable", "--break-on-failure"};
-        argv_helper argv(2, args);
+        argv_helper argv({"executable", "--break-on-failure"});
 
         bd::options opt(argv.argc(), argv.argv());
 
@@ -109,8 +99,7 @@ go_bandit([](){
       });
 
       it("parses the '--dry-run' option", [&](){
-        const char* args[] = {"executable", "--dry-run"};
-        argv_helper argv(2, args);
+        argv_helper argv({"executable", "--dry-run"});
 
         bd::options opt(argv.argc(), argv.argv());
 
@@ -119,8 +108,7 @@ go_bandit([](){
       });
 
       describe("with no arguments", [&](){
-        const char* args[] = {"executable"};
-        argv_helper argv(1, args);
+        argv_helper argv({"executable"});
         bd::options opt(argv.argc(), argv.argv());
 
         it("is valid", [&] {

--- a/specs/options.spec.cpp
+++ b/specs/options.spec.cpp
@@ -1,3 +1,4 @@
+#include <specs/util/argv_helper.h>
 #include <specs/specs.h>
 
 using namespace bandit::specs::util;

--- a/specs/options.spec.cpp
+++ b/specs/options.spec.cpp
@@ -10,106 +10,85 @@ static void all_ok(const bd::options &opt) {
   AssertThat(opt.has_unknown_options(), IsFalse());
 }
 
+struct options : private argv_helper, public bd::options {
+  options(std::list<std::string>&& args)
+    : argv_helper(std::move(args))
+    , bd::options(argc(), argv())
+  {}
+};
+
 go_bandit([](){
 
     describe("options:", [&](){
 
       it("parses the '--help' option", [&](){
-        argv_helper argv({"--help"});
-
-        bd::options opt(argv.argc(), argv.argv());
-
+        options opt({"--help"});
         AssertThat(opt.help(), IsTrue());
         all_ok(opt);
       });
 
       it("parses the '--version' option", [&](){
-        argv_helper argv({"--version"});
-
-        bd::options opt(argv.argc(), argv.argv());
-
+        options opt({"--version"});
         AssertThat(opt.version(), IsTrue());
         all_ok(opt);
       });
 
       it("parses the '--no-color' option", [&](){
-        argv_helper argv({"--no-color"});
-
-        bd::options opt(argv.argc(), argv.argv());
-
+        options opt({"--no-color"});
         AssertThat(opt.no_color(), IsTrue());
         all_ok(opt);
       });
 
       it("parses the '--formatter=vs' option", [&](){
-        argv_helper argv({"--formatter=vs"});
-
-        bd::options opt(argv.argc(), argv.argv());
+        options opt({"--formatter=vs"});
         AssertThat(opt.formatter(), Equals(bd::options::formatters::FORMATTER_VS));
         all_ok(opt);
       });
 
       it("parses the '--formatter=default' option", [&](){
-        argv_helper argv({"--formatter=default"});
-
-        bd::options opt(argv.argc(), argv.argv());
+        options opt({"--formatter=default"});
         AssertThat(opt.formatter(), Equals(bd::options::formatters::FORMATTER_DEFAULT));
         all_ok(opt);
       });
 
       it("parses the '--skip=\"substring\"' option", [&](){
-        argv_helper argv({"--skip=substring"});
-
-        bd::options opt(argv.argc(), argv.argv());
+        options opt({"--skip=substring"});
         AssertThat(opt.skip(), Equals("substring"));
         all_ok(opt);
       });
 
       it("parses skip as empty string if not present", [&](){
-        argv_helper argv({});
-
-        bd::options opt(argv.argc(), argv.argv());
+        options opt({});
         AssertThat(opt.skip(), Equals(""));
         all_ok(opt);
       });
 
       it("parses the '--only=\"substring\"' option", [&](){
-        argv_helper argv({"--only=substring"});
-
-        bd::options opt(argv.argc(), argv.argv());
+        options opt({"--only=substring"});
         AssertThat(opt.only(), Equals("substring"));
         all_ok(opt);
       });
 
       it("parses only as empty string if not present", [&](){
-        argv_helper argv({});
-
-        bd::options opt(argv.argc(), argv.argv());
+        options opt({});
         AssertThat(opt.only(), Equals(""));
         all_ok(opt);
       });
 
       it("parses the '--break-on-failure' option", [&](){
-        argv_helper argv({"--break-on-failure"});
-
-        bd::options opt(argv.argc(), argv.argv());
-
+        options opt({"--break-on-failure"});
         AssertThat(opt.break_on_failure(), IsTrue());
         all_ok(opt);
       });
 
       it("parses the '--dry-run' option", [&](){
-        argv_helper argv({"--dry-run"});
-
-        bd::options opt(argv.argc(), argv.argv());
-
+        options opt({"--dry-run"});
         AssertThat(opt.dry_run(), IsTrue());
         all_ok(opt);
       });
 
       describe("with no arguments", [&](){
-        argv_helper argv({});
-        bd::options opt(argv.argc(), argv.argv());
+        options opt({});
 
         it("is valid", [&] {
           all_ok(opt);

--- a/specs/options.spec.cpp
+++ b/specs/options.spec.cpp
@@ -156,7 +156,7 @@ go_bandit([](){
                      "--dry-run"});
         AssertThat(opt.parsed_ok(), IsTrue());
         AssertThat(opt.formatter(), Equals(bd::options::formatters::VS));
-        AssertThat(opt.reporter(), Equals("xunit"));
+        AssertThat(opt.reporter(), Equals(bd::options::reporters::XUNIT));
         AssertThat(opt.no_color(), IsTrue());
         AssertThat(opt.dry_run(), IsFalse())
         AssertThat(opt.has_further_arguments(), IsTrue());

--- a/specs/options.spec.cpp
+++ b/specs/options.spec.cpp
@@ -120,7 +120,7 @@ go_bandit([](){
         AssertThat(opt.dry_run(), IsFalse())
       });
 
-      it("uses default formatter for '--formatter'", [&](){
+      it_skip("uses default formatter for '--formatter'", [&](){
         AssertThat(opt.formatter(), Equals(bd::options::formatters::DEFAULT));
       });
     });

--- a/specs/options.spec.cpp
+++ b/specs/options.spec.cpp
@@ -18,9 +18,8 @@ struct options : private argv_helper, public bd::options {
 };
 
 go_bandit([](){
-
-    describe("options:", [&](){
-
+  describe("options:", [&](){
+    describe("with valid options", [&] {
       it("parses the '--help' option", [&](){
         options opt({"--help"});
         AssertThat(opt.help(), IsTrue());
@@ -86,6 +85,7 @@ go_bandit([](){
         AssertThat(opt.dry_run(), IsTrue());
         all_ok(opt);
       });
+    });
 
       describe("with no arguments", [&](){
         options opt({});

--- a/specs/options.spec.cpp
+++ b/specs/options.spec.cpp
@@ -87,37 +87,36 @@ go_bandit([](){
       });
     });
 
-      describe("with no arguments", [&](){
-        options opt({});
+    describe("with no arguments", [&](){
+      options opt({});
 
-        it("is valid", [&] {
-          all_ok(opt);
-        });
+      it("is valid", [&] {
+        all_ok(opt);
+      });
 
-        it("cannot find '--help'", [&](){
-          AssertThat(opt.help(), IsFalse());
-        });
+      it("cannot find '--help'", [&](){
+        AssertThat(opt.help(), IsFalse());
+      });
 
-        it("cannot find '--version'", [&](){
-          AssertThat(opt.version(), IsFalse());
-        });
+      it("cannot find '--version'", [&](){
+        AssertThat(opt.version(), IsFalse());
+      });
 
-        it("cannot find '--no-color'", [&](){
-          AssertThat(opt.no_color(), IsFalse());
-        });
+      it("cannot find '--no-color'", [&](){
+        AssertThat(opt.no_color(), IsFalse());
+      });
 
-        it("cannot find '--break-on-failure'", [&](){
-          AssertThat(opt.break_on_failure(), IsFalse())
-        });
+      it("cannot find '--break-on-failure'", [&](){
+        AssertThat(opt.break_on_failure(), IsFalse())
+      });
 
-        it("cannot find '--dry-run'", [&](){
-          AssertThat(opt.dry_run(), IsFalse())
-        });
+      it("cannot find '--dry-run'", [&](){
+        AssertThat(opt.dry_run(), IsFalse())
+      });
 
-        it("uses default formatter for '--formatter'", [&](){
-          AssertThat(opt.formatter(), Equals(bd::options::formatters::FORMATTER_DEFAULT));
-        });
+      it("uses default formatter for '--formatter'", [&](){
+        AssertThat(opt.formatter(), Equals(bd::options::formatters::FORMATTER_DEFAULT));
       });
     });
-
+  });
 });

--- a/specs/options.spec.cpp
+++ b/specs/options.spec.cpp
@@ -3,6 +3,12 @@
 using namespace bandit::specs::util;
 namespace bd = bandit::detail;
 
+static void all_ok(const bd::options &opt) {
+  AssertThat(opt.parsed_ok(), IsTrue());
+  AssertThat(opt.has_further_arguments(), IsFalse());
+  AssertThat(opt.has_unknown_options(), IsFalse());
+}
+
 go_bandit([](){
 
     describe("options:", [&](){
@@ -14,6 +20,7 @@ go_bandit([](){
         bd::options opt(argv.argc(), argv.argv());
 
         AssertThat(opt.help(), IsTrue());
+        all_ok(opt);
       });
 
       it("parses the '--version' option", [&](){
@@ -23,6 +30,7 @@ go_bandit([](){
         bd::options opt(argv.argc(), argv.argv());
 
         AssertThat(opt.version(), IsTrue());
+        all_ok(opt);
       });
 
       it("parses the '--no-color' option", [&](){
@@ -32,6 +40,7 @@ go_bandit([](){
         bd::options opt(argv.argc(), argv.argv());
 
         AssertThat(opt.no_color(), IsTrue());
+        all_ok(opt);
       });
 
       it("parser the '--formatter=vs' option", [&](){
@@ -40,6 +49,7 @@ go_bandit([](){
 
         bd::options opt(argv.argc(), argv.argv());
         AssertThat(opt.formatter(), Equals(bd::options::formatters::FORMATTER_VS));
+        all_ok(opt);
       });
 
       it("parser the '--formatter=default' option", [&](){
@@ -48,6 +58,7 @@ go_bandit([](){
 
         bd::options opt(argv.argc(), argv.argv());
         AssertThat(opt.formatter(), Equals(bd::options::formatters::FORMATTER_DEFAULT));
+        all_ok(opt);
       });
 
       it("parses the '--skip=\"substring\"' option", [&](){
@@ -56,6 +67,7 @@ go_bandit([](){
 
         bd::options opt(argv.argc(), argv.argv());
         AssertThat(opt.skip(), Equals("substring"));
+        all_ok(opt);
       });
 
       it("parses skip as empty string if not present", [&](){
@@ -64,6 +76,7 @@ go_bandit([](){
 
         bd::options opt(argv.argc(), argv.argv());
         AssertThat(opt.skip(), Equals(""));
+        all_ok(opt);
       });
 
       it("parses the '--only=\"substring\"' option", [&](){
@@ -72,6 +85,7 @@ go_bandit([](){
 
         bd::options opt(argv.argc(), argv.argv());
         AssertThat(opt.only(), Equals("substring"));
+        all_ok(opt);
       });
 
       it("parses only as empty string if not present", [&](){
@@ -80,6 +94,7 @@ go_bandit([](){
 
         bd::options opt(argv.argc(), argv.argv());
         AssertThat(opt.only(), Equals(""));
+        all_ok(opt);
       });
 
       it("parses the '--break-on-failure' option", [&](){
@@ -89,6 +104,7 @@ go_bandit([](){
         bd::options opt(argv.argc(), argv.argv());
 
         AssertThat(opt.break_on_failure(), IsTrue());
+        all_ok(opt);
       });
 
       it("parses the '--dry-run' option", [&](){
@@ -98,12 +114,17 @@ go_bandit([](){
         bd::options opt(argv.argc(), argv.argv());
 
         AssertThat(opt.dry_run(), IsTrue());
+        all_ok(opt);
       });
 
       describe("with no arguments", [&](){
         const char* args[] = {"executable"};
         argv_helper argv(1, args);
         bd::options opt(argv.argc(), argv.argv());
+
+        it("is valid", [&] {
+          all_ok(opt);
+        });
 
         it("cannot find '--help'", [&](){
           AssertThat(opt.help(), IsFalse());

--- a/specs/options.spec.cpp
+++ b/specs/options.spec.cpp
@@ -40,19 +40,19 @@ go_bandit([](){
 
       it("parses the '--formatter=vs' option", [&](){
         options opt({"--formatter=vs"});
-        AssertThat(opt.formatter(), Equals(bd::options::formatters::FORMATTER_VS));
+        AssertThat(opt.formatter(), Equals(bd::options::formatters::VS));
         all_ok(opt);
       });
 
       it("parses the '--formatter=vs' option when used without =", [&](){
         options opt({"--formatter", "vs"});
-        AssertThat(opt.formatter(), Equals(bd::options::formatters::FORMATTER_VS));
+        AssertThat(opt.formatter(), Equals(bd::options::formatters::VS));
         all_ok(opt);
       });
 
       it("parses the '--formatter=default' option", [&](){
         options opt({"--formatter=default"});
-        AssertThat(opt.formatter(), Equals(bd::options::formatters::FORMATTER_DEFAULT));
+        AssertThat(opt.formatter(), Equals(bd::options::formatters::DEFAULT));
         all_ok(opt);
       });
 
@@ -121,7 +121,7 @@ go_bandit([](){
       });
 
       it("uses default formatter for '--formatter'", [&](){
-        AssertThat(opt.formatter(), Equals(bd::options::formatters::FORMATTER_DEFAULT));
+        AssertThat(opt.formatter(), Equals(bd::options::formatters::DEFAULT));
       });
     });
 
@@ -155,7 +155,7 @@ go_bandit([](){
                      "unknown-argument",
                      "--dry-run"});
         AssertThat(opt.parsed_ok(), IsTrue());
-        AssertThat(opt.formatter(), Equals(bd::options::formatters::FORMATTER_VS));
+        AssertThat(opt.formatter(), Equals(bd::options::formatters::VS));
         AssertThat(opt.reporter(), Equals("xunit"));
         AssertThat(opt.no_color(), IsTrue());
         AssertThat(opt.dry_run(), IsFalse())

--- a/specs/options.spec.cpp
+++ b/specs/options.spec.cpp
@@ -15,7 +15,7 @@ go_bandit([](){
     describe("options:", [&](){
 
       it("parses the '--help' option", [&](){
-        argv_helper argv({"executable", "--help"});
+        argv_helper argv({"--help"});
 
         bd::options opt(argv.argc(), argv.argv());
 
@@ -24,7 +24,7 @@ go_bandit([](){
       });
 
       it("parses the '--version' option", [&](){
-        argv_helper argv({"executable", "--version"});
+        argv_helper argv({"--version"});
 
         bd::options opt(argv.argc(), argv.argv());
 
@@ -33,7 +33,7 @@ go_bandit([](){
       });
 
       it("parses the '--no-color' option", [&](){
-        argv_helper argv({"executable", "--no-color"});
+        argv_helper argv({"--no-color"});
 
         bd::options opt(argv.argc(), argv.argv());
 
@@ -42,7 +42,7 @@ go_bandit([](){
       });
 
       it("parses the '--formatter=vs' option", [&](){
-        argv_helper argv({"executable", "--formatter=vs"});
+        argv_helper argv({"--formatter=vs"});
 
         bd::options opt(argv.argc(), argv.argv());
         AssertThat(opt.formatter(), Equals(bd::options::formatters::FORMATTER_VS));
@@ -50,7 +50,7 @@ go_bandit([](){
       });
 
       it("parses the '--formatter=default' option", [&](){
-        argv_helper argv({"executable", "--formatter=default"});
+        argv_helper argv({"--formatter=default"});
 
         bd::options opt(argv.argc(), argv.argv());
         AssertThat(opt.formatter(), Equals(bd::options::formatters::FORMATTER_DEFAULT));
@@ -58,7 +58,7 @@ go_bandit([](){
       });
 
       it("parses the '--skip=\"substring\"' option", [&](){
-        argv_helper argv({"executable", "--skip=substring"});
+        argv_helper argv({"--skip=substring"});
 
         bd::options opt(argv.argc(), argv.argv());
         AssertThat(opt.skip(), Equals("substring"));
@@ -66,7 +66,7 @@ go_bandit([](){
       });
 
       it("parses skip as empty string if not present", [&](){
-        argv_helper argv({"executable"});
+        argv_helper argv({});
 
         bd::options opt(argv.argc(), argv.argv());
         AssertThat(opt.skip(), Equals(""));
@@ -74,7 +74,7 @@ go_bandit([](){
       });
 
       it("parses the '--only=\"substring\"' option", [&](){
-        argv_helper argv({"executable", "--only=substring"});
+        argv_helper argv({"--only=substring"});
 
         bd::options opt(argv.argc(), argv.argv());
         AssertThat(opt.only(), Equals("substring"));
@@ -82,7 +82,7 @@ go_bandit([](){
       });
 
       it("parses only as empty string if not present", [&](){
-        argv_helper argv({"executable"});
+        argv_helper argv({});
 
         bd::options opt(argv.argc(), argv.argv());
         AssertThat(opt.only(), Equals(""));
@@ -90,7 +90,7 @@ go_bandit([](){
       });
 
       it("parses the '--break-on-failure' option", [&](){
-        argv_helper argv({"executable", "--break-on-failure"});
+        argv_helper argv({"--break-on-failure"});
 
         bd::options opt(argv.argc(), argv.argv());
 
@@ -99,7 +99,7 @@ go_bandit([](){
       });
 
       it("parses the '--dry-run' option", [&](){
-        argv_helper argv({"executable", "--dry-run"});
+        argv_helper argv({"--dry-run"});
 
         bd::options opt(argv.argc(), argv.argv());
 
@@ -108,7 +108,7 @@ go_bandit([](){
       });
 
       describe("with no arguments", [&](){
-        argv_helper argv({"executable"});
+        argv_helper argv({});
         bd::options opt(argv.argc(), argv.argv());
 
         it("is valid", [&] {

--- a/specs/run.spec.cpp
+++ b/specs/run.spec.cpp
@@ -26,7 +26,7 @@ go_bandit([](){
 
       context_stack = std::unique_ptr<bd::contextstack_t>(new bd::contextstack_t());
 
-      argv = std::unique_ptr<argv_helper>(new argv_helper({"executable"}));
+      argv = std::unique_ptr<argv_helper>(new argv_helper({}));
     });
 
     it("pushes the global context on the context stack", [&](){

--- a/specs/run.spec.cpp
+++ b/specs/run.spec.cpp
@@ -26,8 +26,7 @@ go_bandit([](){
 
       context_stack = std::unique_ptr<bd::contextstack_t>(new bd::contextstack_t());
 
-      const char* args[] = {"executable"};
-      argv = std::unique_ptr<argv_helper>(new argv_helper(1, args));
+      argv = std::unique_ptr<argv_helper>(new argv_helper({"executable"}));
     });
 
     it("pushes the global context on the context stack", [&](){

--- a/specs/run.spec.cpp
+++ b/specs/run.spec.cpp
@@ -1,4 +1,7 @@
+#include <specs/fakes/fake_reporter.h>
+#include <specs/util/argv_helper.h>
 #include <specs/specs.h>
+
 using namespace bandit::fakes;
 using namespace bandit::specs::util;
 namespace bd = bandit::detail;

--- a/specs/specs.h
+++ b/specs/specs.h
@@ -5,7 +5,4 @@
 using namespace bandit;
 using namespace snowhouse;
 
-#include <specs/fakes/fakes.h>
-#include <specs/util/util.h>
-
 #endif

--- a/specs/util/argv_helper.h
+++ b/specs/util/argv_helper.h
@@ -27,6 +27,8 @@ namespace bandit { namespace specs { namespace util {
       }
     }
 
+    argv_helper(const argv_helper &) = default;
+
     ~argv_helper()
     {
       for(int i=0; i < argc_; i++)

--- a/specs/util/argv_helper.h
+++ b/specs/util/argv_helper.h
@@ -1,7 +1,7 @@
 #ifndef BANDIT_SPECS_ARGV_HELPER_H
 #define BANDIT_SPECS_ARGV_HELPER_H
 
-#include <string.h>
+#include <string>
 
 namespace bandit { namespace specs { namespace util {
 

--- a/specs/util/argv_helper.h
+++ b/specs/util/argv_helper.h
@@ -1,37 +1,28 @@
 #ifndef BANDIT_SPECS_ARGV_HELPER_H
 #define BANDIT_SPECS_ARGV_HELPER_H
 
+#include <algorithm>
 #include <string>
 
 namespace bandit { namespace specs { namespace util {
 
-  //
   // main() is supposed to receive its arguments as a non const 'char* argv[]'.
-  // This is a pain to create for each test. It's a whole lot easier to create
-  // a 'const char* argv[]' construct.
+  // This is a pain to create for each test.
   //
-  // This class helps copy from 'const char**' to 'char**' and handle cleanup
-  // automatically.
-  //
+  // This class makes up an argc/argv pair from a simple std::initializer_list
   struct argv_helper
   {
-    argv_helper(int argc_a, const char* argv_a[])
-      : argc_(argc_a) 
+    argv_helper(std::initializer_list<std::string> args)
+      : argc_(args.size())
     {
       non_const_argv_ = new char*[argc_];
-      for(int i=0; i < argc_; i++)
-      {
-		std::string s(argv_a[i]);
-        non_const_argv_[i] = new char[s.size() + 1];
-        for(size_t c=0;c<s.size();c++)
-		{
-			non_const_argv_[i][c] = s[c];
-		}
-		non_const_argv_[i][s.size()] = 0;
+      size_t i = 0;
+      for (auto arg : args) {
+        non_const_argv_[i] = new char[arg.size() + 1];
+        std::copy(arg.begin(), arg.end() + 1, non_const_argv_[i]);
+        ++i;
       }
     }
-
-
 
     ~argv_helper()
     {
@@ -53,10 +44,9 @@ namespace bandit { namespace specs { namespace util {
       return argc_;
     }
 
-    private:
+  private:
     int argc_;
     char** non_const_argv_;
   };
-
 }}}
 #endif

--- a/specs/util/argv_helper.h
+++ b/specs/util/argv_helper.h
@@ -2,6 +2,7 @@
 #define BANDIT_SPECS_ARGV_HELPER_H
 
 #include <algorithm>
+#include <list>
 #include <string>
 
 namespace bandit { namespace specs { namespace util {
@@ -9,12 +10,14 @@ namespace bandit { namespace specs { namespace util {
   // main() is supposed to receive its arguments as a non const 'char* argv[]'.
   // This is a pain to create for each test.
   //
-  // This class makes up an argc/argv pair from a simple std::initializer_list
+  // This class makes up an argc/argv pair from a simple brace-enclosed initializer list.
+  // The first executable "argument" is already included.
   struct argv_helper
   {
-    argv_helper(std::initializer_list<std::string> args)
-      : argc_(args.size())
+    argv_helper(std::list<std::string>&& args)
+      : argc_(args.size() + 1)
     {
+      args.emplace_front("executable");
       non_const_argv_ = new char*[argc_];
       size_t i = 0;
       for (auto arg : args) {

--- a/specs/util/argv_helper.h
+++ b/specs/util/argv_helper.h
@@ -1,7 +1,6 @@
 #ifndef BANDIT_SPECS_ARGV_HELPER_H
 #define BANDIT_SPECS_ARGV_HELPER_H
 
-#include <algorithm>
 #include <list>
 #include <string>
 
@@ -22,7 +21,8 @@ namespace bandit { namespace specs { namespace util {
       size_t i = 0;
       for (auto arg : args) {
         non_const_argv_[i] = new char[arg.size() + 1];
-        std::copy(arg.begin(), arg.end() + 1, non_const_argv_[i]);
+        arg.copy(non_const_argv_[i], arg.size());
+        non_const_argv_[i][arg.size()] = '\0';
         ++i;
       }
     }

--- a/specs/util/util.h
+++ b/specs/util/util.h
@@ -1,6 +1,0 @@
-#ifndef BANDIT_SPECS_UTIL_H
-#define BANDIT_SPECS_UTIL_H
-
-#include "argv_helper.h"
-
-#endif


### PR DESCRIPTION
The main change for the user is that options are
checked now. By default, option usage errors do not
lead to failed return values, but you can add a `false`
to your `bandit::run` call to enable that.

The main internal change is that the code behind
choice-based options like `--formatter` and `--reporter`
are unified.

The options spec is extended to reflect those changes.