### PR TITLE
Replace skip/only patterns by filter chain

### DIFF
--- a/bandit/filter_chain.h
+++ b/bandit/filter_chain.h
@@ -1,0 +1,17 @@
+#ifndef BANDIT_FILTER_CHAIN_H
+#define BANDIT_FILTER_CHAIN_H
+
+#include <string>
+#include <vector>
+
+namespace bandit {
+  namespace detail {
+    struct filter_chain_element {
+      std::string pattern;
+      bool skip;
+    };
+
+    using filter_chain_t = std::vector<filter_chain_element>;
+  }
+}
+#endif

--- a/bandit/options.h
+++ b/bandit/options.h
@@ -6,6 +6,7 @@
 #include <iostream>
 
 #include <bandit/external/optionparser.h>
+#include <bandit/filter_chain.h>
 
 namespace bandit {
   namespace detail {
@@ -164,6 +165,18 @@ namespace bandit {
         parsed_ok_ = !parse.error();
         has_further_arguments_ = (parse.nonOptionsCount() != 0);
         has_unknown_options_ = (options_[UNKNOWN] != nullptr);
+
+        for (int i = 0; i < parse.optionsCount(); ++i) {
+          option::Option& opt = buffer[i];
+          switch (opt.index()) {
+          case SKIP:
+            filter_chain_.push_back({opt.arg, true});
+            break;
+          case ONLY:
+            filter_chain_.push_back({opt.arg, false});
+            break;
+          }
+        }
       }
 
       bool help() const {
@@ -202,12 +215,8 @@ namespace bandit {
         return get_enumerator_from_string(argument::formatter_list(), options_[FORMATTER].arg);
       }
 
-      const char* skip() const {
-        return options_[SKIP].arg ? options_[SKIP].arg : "";
-      }
-
-      const char* only() const {
-        return options_[ONLY].arg ? options_[ONLY].arg : "";
+      const filter_chain_t& filter_chain() const {
+        return filter_chain_;
       }
 
       bool break_on_failure() const {
@@ -281,6 +290,7 @@ namespace bandit {
 
     private:
       std::vector<option::Option> options_;
+      filter_chain_t filter_chain_;
       bool parsed_ok_;
       bool has_further_arguments_;
       bool has_unknown_options_;

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -11,7 +11,7 @@
 namespace bandit {
   namespace detail {
     inline run_policy_ptr create_run_policy(const options& opt) {
-      return run_policy_ptr(new bandit_run_policy(opt.skip(), opt.only(), opt.break_on_failure(), opt.dry_run()));
+      return run_policy_ptr(new bandit_run_policy(opt.filter_chain(), opt.break_on_failure(), opt.dry_run()));
     }
 
     inline listener_ptr create_reporter(const options& opt,

--- a/specs/options.spec.cpp
+++ b/specs/options.spec.cpp
@@ -84,27 +84,39 @@ go_bandit([]() {
         all_ok(opt);
       });
 
-      it("parses the '--skip=\"substring\"' option", [&]() {
+      it("parses the '--skip=\"substring\"' option once", [&]() {
         options opt({"--skip=substring"});
-        AssertThat(opt.skip(), Equals("substring"));
-        all_ok(opt);
-      });
-
-      it("parses skip as empty string if not present", [&]() {
-        options opt({});
-        AssertThat(opt.skip(), Equals(""));
+        AssertThat(opt.filter_chain(), HasLength(1));
+        AssertThat(opt.filter_chain().front().pattern, Equals("substring"));
+        AssertThat(opt.filter_chain().front().skip, IsTrue());
         all_ok(opt);
       });
 
       it("parses the '--only=\"substring\"' option", [&]() {
         options opt({"--only=substring"});
-        AssertThat(opt.only(), Equals("substring"));
+        AssertThat(opt.filter_chain(), HasLength(1));
+        AssertThat(opt.filter_chain().front().pattern, Equals("substring"));
+        AssertThat(opt.filter_chain().front().skip, IsFalse());
         all_ok(opt);
       });
 
-      it("parses only as empty string if not present", [&]() {
+      it("parses multiple --skip and --only options correctly", [&]() {
+        options opt({"--skip=s1", "--only=o2", "--skip=s3", "--only=o4"});
+        AssertThat(opt.filter_chain(), HasLength(4));
+        AssertThat(opt.filter_chain()[0].pattern, Equals("s1"));
+        AssertThat(opt.filter_chain()[0].skip, IsTrue());
+        AssertThat(opt.filter_chain()[1].pattern, Equals("o2"));
+        AssertThat(opt.filter_chain()[1].skip, IsFalse());
+        AssertThat(opt.filter_chain()[2].pattern, Equals("s3"));
+        AssertThat(opt.filter_chain()[2].skip, IsTrue());
+        AssertThat(opt.filter_chain()[3].pattern, Equals("o4"));
+        AssertThat(opt.filter_chain()[3].skip, IsFalse());
+        all_ok(opt);
+      });
+
+      it("has an empty filter chain if neither --skip nor --only are present", [&]() {
         options opt({});
-        AssertThat(opt.only(), Equals(""));
+        AssertThat(opt.filter_chain(), IsEmpty());
         all_ok(opt);
       });
 


### PR DESCRIPTION
A filter chain is now used by run policies instead of
skip/only patterns.

This allows a more intuitive usage of (multiple) --skip
and --only options.

However, this comes with a compatibility-breaking change:
Up to this commit, context skips were ignored if there are
matching "only"s. This behavior is now changed. --skip
and --only apply a filter (the one or the other way),
no matter in what "stage" they match.

This resolves #88.