### PR TITLE
Report successful run even if no specs found

### DIFF
--- a/bandit/reporters/info_reporter.h
+++ b/bandit/reporters/info_reporter.h
@@ -269,11 +269,6 @@ namespace bandit {
         stm_.flush();
       }
 
-      bool did_we_pass() const override {
-        return specs_failed_ == 0 &&
-               test_run_errors_.size() == 0;
-      }
-
     private:
       std::string indent() {
         return std::string(2 * indentation_, ' ');

--- a/bandit/reporters/progress_reporter.h
+++ b/bandit/reporters/progress_reporter.h
@@ -74,8 +74,8 @@ namespace bandit {
         specs_skipped_++;
       }
 
-      bool did_we_pass() const override {
-        return specs_run_ > 0 && specs_failed_ == 0 && test_run_errors_.size() == 0;
+      bool did_we_pass() const override final {
+        return specs_failed_ == 0 && test_run_errors_.size() == 0;
       }
 
     protected:

--- a/specs/reporters/dots_reporter.spec.cpp
+++ b/specs/reporters/dots_reporter.spec.cpp
@@ -26,8 +26,8 @@ go_bandit([]() {
         AssertThat(output(), Equals("\nCould not find any tests.\n"));
       });
 
-      it("is not considered successful", [&]() {
-        AssertThat(reporter->did_we_pass(), Equals(false));
+      it("is considered successful", [&]() {
+        AssertThat(reporter->did_we_pass(), IsTrue());
       });
     });
 

--- a/specs/reporters/single_line_reporter.spec.cpp
+++ b/specs/reporters/single_line_reporter.spec.cpp
@@ -26,8 +26,8 @@ go_bandit([]() {
         AssertThat(output(), Equals("\nCould not find any tests.\n"));
       });
 
-      it("is not considered successful", [&]() {
-        AssertThat(reporter->did_we_pass(), Equals(false));
+      it("is considered successful", [&]() {
+        AssertThat(reporter->did_we_pass(), IsTrue());
       });
     });
 


### PR DESCRIPTION
This reverts e271234b4deedbda4e0a23dafd34b2a950d066d6 semantically.
Issue #10 is not considered as a bug but as a feature.

When the user intends to skip all tests for some reason, it should
not be considered being a failure.

This is a compatibility-breaking change.