### PR TITLE
Add crash reporter

### DIFF
--- a/bandit/options.h
+++ b/bandit/options.h
@@ -81,12 +81,14 @@ namespace bandit {
         INFO,
         SPEC,
         DOTS,
+        CRASH,
         UNKNOWN
       };
 
       struct argument : public option::Arg {
         static const argstrs<reporters> reporter_list() {
           return {
+              {reporters::CRASH, "crash"},
               {reporters::DOTS, "dots"},
               {reporters::SINGLELINE, "singleline"},
               {reporters::XUNIT, "xunit"},

--- a/bandit/reporters/crash_reporter.h
+++ b/bandit/reporters/crash_reporter.h
@@ -1,0 +1,94 @@
+#ifndef BANDIT_CRASH_REPORTER_H
+#define BANDIT_CRASH_REPORTER_H
+
+#include <vector>
+#include <bandit/reporters/progress_reporter.h>
+#include <bandit/reporters/test_run_summary.h>
+
+namespace bandit {
+  namespace detail {
+    struct crash_reporter : public progress_reporter {
+      crash_reporter(std::ostream& stm, const failure_formatter& failure_formatter)
+          : progress_reporter(failure_formatter), stm_(stm), contexts_() {}
+
+      crash_reporter(const failure_formatter& failure_formatter)
+          : crash_reporter(std::cout, failure_formatter) {}
+
+      crash_reporter& operator=(const crash_reporter&) {
+        return *this;
+      }
+
+      void test_run_complete() override {
+        progress_reporter::test_run_complete();
+        for (auto failure : failures_) {
+          stm_ << std::endl
+               << "# FAILED " << failure;
+        }
+        for (auto error : test_run_errors_) {
+          stm_ << std::endl
+               << "# ERROR " << error;
+        }
+        stm_.flush();
+      }
+
+      void test_run_error(const std::string& desc, const struct test_run_error& err) override {
+        progress_reporter::test_run_error(desc, err);
+        std::stringstream ss;
+        ss << current_context_name() << ": " << desc << ": " << err.what() << std::endl;
+        test_run_errors_.push_back(ss.str());
+      }
+
+      void context_starting(const std::string& desc) override {
+        progress_reporter::context_starting(desc);
+        contexts_.emplace_back(desc);
+      }
+
+      void context_ended(const std::string& desc) override {
+        progress_reporter::context_ended(desc);
+        contexts_.pop_back();
+      }
+
+      void it_skip(const std::string& desc) override {
+        progress_reporter::it_skip(desc);
+      }
+
+      void it_starting(const std::string& desc) override {
+        progress_reporter::it_starting(desc);
+        for (auto context : contexts_) {
+          stm_ << context << " | ";
+        }
+        stm_ << desc << std::endl;
+      }
+
+      void it_succeeded(const std::string& desc) override {
+        progress_reporter::it_succeeded(desc);
+      }
+
+      void it_failed(const std::string& desc, const assertion_exception& ex) override {
+        ++specs_failed_;
+
+        std::stringstream ss;
+        ss << current_context_name() << " " << desc << ":" << std::endl
+           << failure_formatter_.format(ex);
+        failures_.push_back(ss.str());
+
+        stm_ << "FAILED" << std::endl;
+      }
+
+      void it_unknown_error(const std::string& desc) override {
+        ++specs_failed_;
+
+        std::stringstream ss;
+        ss << current_context_name() << " " << desc << ": Unknown exception" << std::endl;
+        failures_.push_back(ss.str());
+
+        stm_ << "UNKNOWN EXCEPTION" << std::endl;
+      }
+
+    private:
+      std::ostream& stm_;
+      std::vector<std::string> contexts_;
+    };
+  }
+}
+#endif

--- a/bandit/reporters/reporters.h
+++ b/bandit/reporters/reporters.h
@@ -6,6 +6,7 @@
 #include <bandit/reporters/xunit_reporter.h>
 #include <bandit/reporters/info_reporter.h>
 #include <bandit/reporters/spec_reporter.h>
+#include <bandit/reporters/crash_reporter.h>
 
 namespace bandit {
   namespace detail {

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -25,6 +25,8 @@ namespace bandit {
         return listener_ptr(new info_reporter(*formatter, colorizer));
       case options::reporters::SPEC:
         return listener_ptr(new spec_reporter(*formatter, colorizer));
+      case options::reporters::CRASH:
+        return listener_ptr(new crash_reporter(*formatter));
       case options::reporters::DOTS:
       default:
         return listener_ptr(new dots_reporter(*formatter, colorizer));

--- a/specs/reporters/crash_reporter.spec.cpp
+++ b/specs/reporters/crash_reporter.spec.cpp
@@ -1,0 +1,117 @@
+#include <specs/specs.h>
+
+namespace bd = bandit::detail;
+
+go_bandit([]() {
+  describe("crash_reporter:", [&]() {
+    std::stringstream stm;
+    std::unique_ptr<bd::crash_reporter> reporter;
+    bd::default_failure_formatter formatter;
+
+    before_each([&]() {
+      stm.str(std::string());
+      reporter = std::unique_ptr<bd::crash_reporter>(new bd::crash_reporter(stm, formatter));
+    });
+
+    auto output = [&]() {
+      return stm.str();
+    };
+
+    it("has empty output on empty test set", [&]() {
+      reporter->test_run_starting();
+      reporter->test_run_complete();
+      AssertThat(output(), IsEmpty());
+    });
+
+    it("has expected output for a successful test", [&]() {
+      reporter->test_run_starting();
+      reporter->context_starting("context");
+      reporter->it_starting("passes");
+      reporter->it_succeeded("passes");
+      reporter->context_ended("context");
+      reporter->test_run_complete();
+      AssertThat(output(), Equals("context | passes\n"));
+    });
+
+    it("has expected output for a successful and a failing test", [&]() {
+      reporter->test_run_starting();
+      reporter->context_starting("context");
+      reporter->it_starting("passes");
+      reporter->it_succeeded("passes");
+      reporter->it_starting("fails");
+      bd::assertion_exception exception("assertion failed!", "some_file", 123);
+      reporter->it_failed("fails", exception);
+      reporter->context_ended("context");
+      reporter->test_run_complete();
+      AssertThat(output(), Contains("context | passes\ncontext | fails\nFAILED"));
+      AssertThat(output(), Contains("# FAILED context fails:\nsome_file:123: assertion failed!"));
+    });
+
+    it("has expected output for a non-assertion_exception", [&]() {
+      reporter->test_run_starting();
+      reporter->context_starting("context");
+      reporter->it_starting("throws an unknown exception");
+      reporter->it_unknown_error("throws an unknown exception");
+      reporter->context_ended("context");
+      reporter->test_run_complete();
+      AssertThat(output(), Contains("context | throws an unknown exception\nUNKNOWN EXCEPTION"));
+      AssertThat(output(), Contains("# FAILED context throws an unknown exception: Unknown exception"));
+    });
+
+    it("has expected output for a failing test with nested contexts", [&]() {
+      reporter->test_run_starting();
+      reporter->context_starting("context");
+      reporter->it_starting("passes");
+      reporter->it_succeeded("passes");
+      reporter->context_starting("nested context");
+      reporter->it_starting("fails");
+      bd::assertion_exception exception("assertion failed!", "some_file", 123);
+      reporter->it_failed("fails", exception);
+      reporter->context_ended("a nested context");
+      reporter->context_ended("my context");
+      reporter->test_run_complete();
+      AssertThat(output(), Contains("context | passes\ncontext | nested context | fails\nFAILED"));
+      AssertThat(output(), Contains("# FAILED context nested context fails:\nsome_file:123: assertion failed!"));
+    });
+
+    it("has expected output for test run errors within a context", [&]() {
+      reporter->test_run_starting();
+      reporter->context_starting("context");
+      reporter->context_starting("nested context");
+      bd::test_run_error error("error!");
+      reporter->test_run_error("desc", error);
+      reporter->context_ended("nested context");
+      reporter->context_ended("context");
+      reporter->test_run_complete();
+      AssertThat(output(), Contains("# ERROR context nested context: desc: error!\n"));
+    });
+
+    it("has no output for skipped tests", [&]() {
+      reporter->test_run_starting();
+      reporter->context_starting("context");
+      reporter->it_skip("skips");
+      reporter->it_starting("passes");
+      reporter->it_succeeded("passes");
+      reporter->it_skip("skips");
+      reporter->it_starting("fails");
+      bd::assertion_exception exception("assertion failed!", "some_file", 123);
+      reporter->it_failed("fails", exception);
+      reporter->it_skip("skips");
+      reporter->context_ended("context");
+      reporter->test_run_complete();
+      AssertThat(output(), Contains("context | fails\nFAILED"));
+      AssertThat(output(), Contains("# FAILED context fails:\nsome_file:123: assertion failed!"));
+    });
+
+    it("has empty output in case all tests are skipped", [&]() {
+      reporter->test_run_starting();
+      reporter->context_starting("context");
+      reporter->it_skip("skips first");
+      reporter->it_skip("skips second");
+      reporter->it_skip("skips last");
+      reporter->context_ended("context");
+      reporter->test_run_complete();
+      AssertThat(output(), IsEmpty());
+    });
+  });
+});


### PR DESCRIPTION
The crash reporter is a reporter that is suited for test suites
that can crash (segmentation fault and alike) and when multiple
bandit invokations are run in parallel.

When a test item is started, the crash reporter prints the
whole context (separated by " | ") and the item on one line.

The test summary only contains failures and is prefixed by
'#' so that you can grep for it. For example, using the default
failure formatter,

```sh
run_tests --reporter=crash >log 2>&1 ||
   grep -B 1 -A 4 "^#" log ||
   tail -n 10 log
```

gives a nice output of the failure summary (if there are failures)
or outputs the last 10 lines of the output (if it crashes)
or is just silent otherwise.

Resolves #83 where such a reporter has been requested.