### PR TITLE
Fix clang warnings

### DIFF
--- a/bandit/assertion_exception.h
+++ b/bandit/assertion_exception.h
@@ -2,6 +2,7 @@
 #define BANDIT_ASSERTION_EXCEPTION_H
 
 #include <stdexcept>
+#include <string>
 
 namespace bandit {
   namespace detail {

--- a/bandit/reporters/crash_reporter.h
+++ b/bandit/reporters/crash_reporter.h
@@ -9,7 +9,7 @@ namespace bandit {
   namespace detail {
     struct crash_reporter : public progress_reporter {
       crash_reporter(std::ostream& stm, const failure_formatter& failure_formatter)
-          : progress_reporter(failure_formatter), stm_(stm), cr_contexts_() {}
+          : progress_reporter(failure_formatter), stm_(stm) {}
 
       crash_reporter(const failure_formatter& failure_formatter)
           : crash_reporter(std::cout, failure_formatter) {}
@@ -38,23 +38,13 @@ namespace bandit {
         test_run_errors_.push_back(ss.str());
       }
 
-      void context_starting(const std::string& desc) override {
-        progress_reporter::context_starting(desc);
-        cr_contexts_.emplace_back(desc);
-      }
-
-      void context_ended(const std::string& desc) override {
-        progress_reporter::context_ended(desc);
-        cr_contexts_.pop_back();
-      }
-
       void it_skip(const std::string& desc) override {
         progress_reporter::it_skip(desc);
       }
 
       void it_starting(const std::string& desc) override {
         progress_reporter::it_starting(desc);
-        for (auto context : cr_contexts_) {
+        for (auto context : contexts_) {
           stm_ << context << " | ";
         }
         stm_ << desc << std::endl;
@@ -87,7 +77,6 @@ namespace bandit {
 
     private:
       std::ostream& stm_;
-      std::vector<std::string> cr_contexts_;
     };
   }
 }

--- a/bandit/reporters/crash_reporter.h
+++ b/bandit/reporters/crash_reporter.h
@@ -9,7 +9,7 @@ namespace bandit {
   namespace detail {
     struct crash_reporter : public progress_reporter {
       crash_reporter(std::ostream& stm, const failure_formatter& failure_formatter)
-          : progress_reporter(failure_formatter), stm_(stm), contexts_() {}
+          : progress_reporter(failure_formatter), stm_(stm), cr_contexts_() {}
 
       crash_reporter(const failure_formatter& failure_formatter)
           : crash_reporter(std::cout, failure_formatter) {}
@@ -40,12 +40,12 @@ namespace bandit {
 
       void context_starting(const std::string& desc) override {
         progress_reporter::context_starting(desc);
-        contexts_.emplace_back(desc);
+        cr_contexts_.emplace_back(desc);
       }
 
       void context_ended(const std::string& desc) override {
         progress_reporter::context_ended(desc);
-        contexts_.pop_back();
+        cr_contexts_.pop_back();
       }
 
       void it_skip(const std::string& desc) override {
@@ -54,7 +54,7 @@ namespace bandit {
 
       void it_starting(const std::string& desc) override {
         progress_reporter::it_starting(desc);
-        for (auto context : contexts_) {
+        for (auto context : cr_contexts_) {
           stm_ << context << " | ";
         }
         stm_ << desc << std::endl;
@@ -87,7 +87,7 @@ namespace bandit {
 
     private:
       std::ostream& stm_;
-      std::vector<std::string> contexts_;
+      std::vector<std::string> cr_contexts_;
     };
   }
 }

--- a/bandit/reporters/info_reporter.h
+++ b/bandit/reporters/info_reporter.h
@@ -97,7 +97,7 @@ namespace bandit {
             << std::endl;
       }
 
-      void test_run_complete() {
+      void test_run_complete() override {
         progress_reporter::test_run_complete();
         stm_ << std::endl;
         list_failures_and_errors();
@@ -105,7 +105,7 @@ namespace bandit {
         stm_.flush();
       }
 
-      void test_run_error(const std::string& desc, const struct test_run_error& err) {
+      void test_run_error(const std::string& desc, const struct test_run_error& err) override {
         progress_reporter::test_run_error(desc, err);
 
         std::stringstream ss;


### PR DESCRIPTION
This fixes warnings associated with 1) missing overrides, 2) not including #string in assertion_exception.h, 3) shadowing of contexts_.