### PR TITLE
Introduce choosable colorizers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ endif()
 if (BANDIT_BUILD_SPECS AND BANDIT_RUN_SPECS)
     add_custom_command(TARGET bandit-specs
                        POST_BUILD
-                       COMMAND bandit-specs --no-color --reporter=dots
+                       COMMAND bandit-specs --colorizer=off --reporter=dots
                        WORKING_DIRECTORY ./bin)
 elseif (BANDIT_RUN_SPECS)
     message(WARNING "Unable to run Bandit specs - set:\n  option(BANDIT_BUILD_SPECS, \"Build the Bandit specs\" ON)\nand clear your CMake cache")

--- a/bandit/colorizers.h
+++ b/bandit/colorizers.h
@@ -1,6 +1,7 @@
 #ifndef BANDIT_COLORIZERS_H
 #define BANDIT_COLORIZERS_H
 
+#include <bandit/colorizers/dark.h>
 #include <bandit/colorizers/light.h>
 #include <bandit/colorizers/off.h>
 

--- a/bandit/colorizers.h
+++ b/bandit/colorizers.h
@@ -1,0 +1,6 @@
+#ifndef BANDIT_COLORIZERS_H
+#define BANDIT_COLORIZERS_H
+
+#include <bandit/colorizers/light.h>
+
+#endif

--- a/bandit/colorizers.h
+++ b/bandit/colorizers.h
@@ -2,5 +2,6 @@
 #define BANDIT_COLORIZERS_H
 
 #include <bandit/colorizers/light.h>
+#include <bandit/colorizers/off.h>
 
 #endif

--- a/bandit/colorizers/backend.h
+++ b/bandit/colorizers/backend.h
@@ -15,53 +15,39 @@ namespace bandit {
   namespace colorizer {
     struct backend {
 #if defined(_WIN32) && !defined(BANDIT_CONFIG_COLOR_ANSI)
-      backend(bool colors_enabled = true)
-          : colors_enabled_(colors_enabled),
-            stdout_handle_(GetStdHandle(STD_OUTPUT_HANDLE)) {
+      backend() : stdout_handle_(GetStdHandle(STD_OUTPUT_HANDLE)) {
         background_color_ = original_color_ = get_console_color();
         background_color_ &= BACKGROUND_BLUE | BACKGROUND_GREEN | BACKGROUND_RED | BACKGROUND_INTENSITY;
       }
 
       const std::string green() const {
-        if (colors_enabled_) {
-          set_console_color(FOREGROUND_GREEN | FOREGROUND_INTENSITY | background_color_);
-        }
+        set_console_color(FOREGROUND_GREEN | FOREGROUND_INTENSITY | background_color_);
         return "";
       }
 
       const std::string yellow() const {
-        if (colors_enabled_) {
-          set_console_color(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY | background_color_);
-        }
+        set_console_color(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY | background_color_);
         return "";
       }
 
       const std::string blue() const {
-        if (colors_enabled_) {
-          set_console_color(FOREGROUND_BLUE | FOREGROUND_INTENSITY | background_color_);
-        }
+        set_console_color(FOREGROUND_BLUE | FOREGROUND_INTENSITY | background_color_);
         return "";
       }
 
       const std::string red() const {
-        if (colors_enabled_) {
-          set_console_color(FOREGROUND_RED | FOREGROUND_INTENSITY | background_color_);
-        }
+        set_console_color(FOREGROUND_RED | FOREGROUND_INTENSITY | background_color_);
         return "";
       }
 
       const std::string white() const {
-        if (colors_enabled_) {
-          set_console_color(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE |
-              FOREGROUND_INTENSITY | background_color_);
-        }
+        set_console_color(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE |
+            FOREGROUND_INTENSITY | background_color_);
         return "";
       }
 
       const std::string reset() const {
-        if (colors_enabled_) {
-          set_console_color(original_color_);
-        }
+        set_console_color(original_color_);
         return "";
       }
 
@@ -77,39 +63,33 @@ namespace bandit {
       }
 
     private:
-      bool colors_enabled_;
       HANDLE stdout_handle_;
       WORD original_color_;
       WORD background_color_;
 #else
-      backend(bool colors_enabled = true) : colors_enabled_(colors_enabled) {}
-
       const std::string green() const {
-        return colors_enabled_ ? "\033[1;32m" : "";
+        return "\033[1;32m";
       }
 
       const std::string yellow() const {
-        return colors_enabled_ ? "\033[1;33m" : "";
+        return "\033[1;33m";
       }
 
       const std::string blue() const {
-        return colors_enabled_ ? "\033[1;34m" : "";
+        return "\033[1;34m";
       }
 
       const std::string red() const {
-        return colors_enabled_ ? "\033[1;31m" : "";
+        return "\033[1;31m";
       }
 
       const std::string white() const {
-        return colors_enabled_ ? "\033[1;37m" : "";
+        return "\033[1;37m";
       }
 
       const std::string reset() const {
-        return colors_enabled_ ? "\033[0m" : "";
+        return "\033[0m";
       }
-
-    private:
-      bool colors_enabled_;
 #endif
     };
   }

--- a/bandit/colorizers/backend.h
+++ b/bandit/colorizers/backend.h
@@ -1,0 +1,117 @@
+#ifndef BANDIT_COLORIZERS_BACKEND_H
+#define BANDIT_COLORIZERS_BACKEND_H
+
+#include <string>
+
+#if defined(_WIN32) && !defined(BANDIT_CONFIG_COLOR_ANSI)
+#  ifndef NOMINMAX
+#    define NOMINMAX
+#  endif
+#  define WIN32_LEAN_AND_MEAN
+#  include <windows.h>
+#endif
+
+namespace bandit {
+  namespace colorizer {
+    struct backend {
+#if defined(_WIN32) && !defined(BANDIT_CONFIG_COLOR_ANSI)
+      backend(bool colors_enabled = true)
+          : colors_enabled_(colors_enabled),
+            stdout_handle_(GetStdHandle(STD_OUTPUT_HANDLE)) {
+        background_color_ = original_color_ = get_console_color();
+        background_color_ &= BACKGROUND_BLUE | BACKGROUND_GREEN | BACKGROUND_RED | BACKGROUND_INTENSITY;
+      }
+
+      const std::string green() const {
+        if (colors_enabled_) {
+          set_console_color(FOREGROUND_GREEN | FOREGROUND_INTENSITY | background_color_);
+        }
+        return "";
+      }
+
+      const std::string yellow() const {
+        if (colors_enabled_) {
+          set_console_color(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY | background_color_);
+        }
+        return "";
+      }
+
+      const std::string blue() const {
+        if (colors_enabled_) {
+          set_console_color(FOREGROUND_BLUE | FOREGROUND_INTENSITY | background_color_);
+        }
+        return "";
+      }
+
+      const std::string red() const {
+        if (colors_enabled_) {
+          set_console_color(FOREGROUND_RED | FOREGROUND_INTENSITY | background_color_);
+        }
+        return "";
+      }
+
+      const std::string white() const {
+        if (colors_enabled_) {
+          set_console_color(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE |
+              FOREGROUND_INTENSITY | background_color_);
+        }
+        return "";
+      }
+
+      const std::string reset() const {
+        if (colors_enabled_) {
+          set_console_color(original_color_);
+        }
+        return "";
+      }
+
+    private:
+      WORD get_console_color() const {
+        CONSOLE_SCREEN_BUFFER_INFO info{};
+        GetConsoleScreenBufferInfo(stdout_handle_, &info);
+        return info.wAttributes;
+      }
+
+      void set_console_color(WORD color) const {
+        SetConsoleTextAttribute(stdout_handle_, color);
+      }
+
+    private:
+      bool colors_enabled_;
+      HANDLE stdout_handle_;
+      WORD original_color_;
+      WORD background_color_;
+#else
+      backend(bool colors_enabled = true) : colors_enabled_(colors_enabled) {}
+
+      const std::string green() const {
+        return colors_enabled_ ? "\033[1;32m" : "";
+      }
+
+      const std::string yellow() const {
+        return colors_enabled_ ? "\033[1;33m" : "";
+      }
+
+      const std::string blue() const {
+        return colors_enabled_ ? "\033[1;34m" : "";
+      }
+
+      const std::string red() const {
+        return colors_enabled_ ? "\033[1;31m" : "";
+      }
+
+      const std::string white() const {
+        return colors_enabled_ ? "\033[1;37m" : "";
+      }
+
+      const std::string reset() const {
+        return colors_enabled_ ? "\033[0m" : "";
+      }
+
+    private:
+      bool colors_enabled_;
+#endif
+    };
+  }
+}
+#endif

--- a/bandit/colorizers/backend.h
+++ b/bandit/colorizers/backend.h
@@ -20,8 +20,18 @@ namespace bandit {
         background_color_ &= BACKGROUND_BLUE | BACKGROUND_GREEN | BACKGROUND_RED | BACKGROUND_INTENSITY;
       }
 
+      const std::string dark_green() const {
+        set_console_color(FOREGROUND_GREEN | background_color_);
+        return "";
+      }
+
       const std::string green() const {
         set_console_color(FOREGROUND_GREEN | FOREGROUND_INTENSITY | background_color_);
+        return "";
+      }
+
+      const std::string brown() const {
+        set_console_color(FOREGROUND_RED | FOREGROUND_GREEN | background_color_);
         return "";
       }
 
@@ -30,13 +40,28 @@ namespace bandit {
         return "";
       }
 
+      const std::string dark_blue() const {
+        set_console_color(FOREGROUND_BLUE | FOREGROUND_INTENSITY | background_color_);
+        return "";
+      }
+
       const std::string blue() const {
         set_console_color(FOREGROUND_BLUE | FOREGROUND_INTENSITY | background_color_);
         return "";
       }
 
+      const std::string dark_red() const {
+        set_console_color(FOREGROUND_RED | background_color_);
+        return "";
+      }
+
       const std::string red() const {
         set_console_color(FOREGROUND_RED | FOREGROUND_INTENSITY | background_color_);
+        return "";
+      }
+
+      const std::string dark_gray() const {
+        set_console_color(FOREGROUND_INTENSITY | background_color_);
         return "";
       }
 
@@ -67,20 +92,40 @@ namespace bandit {
       WORD original_color_;
       WORD background_color_;
 #else
+      const std::string dark_green() const {
+        return "\033[0;32m";
+      }
+
       const std::string green() const {
         return "\033[1;32m";
+      }
+
+      const std::string brown() const {
+        return "\033[0;33m";
       }
 
       const std::string yellow() const {
         return "\033[1;33m";
       }
 
+      const std::string dark_blue() const {
+        return "\033[0;34m";
+      }
+
       const std::string blue() const {
         return "\033[1;34m";
       }
 
+      const std::string dark_red() const {
+        return "\033[0;31m";
+      }
+
       const std::string red() const {
         return "\033[1;31m";
+      }
+
+      const std::string dark_gray() const {
+        return "\033[1;30m";
       }
 
       const std::string white() const {

--- a/bandit/colorizers/colorizer.h
+++ b/bandit/colorizers/colorizer.h
@@ -1,119 +1,37 @@
 #ifndef BANDIT_COLORIZERS_COLORIZER_H
 #define BANDIT_COLORIZERS_COLORIZER_H
 
-#include <string>
-
-#if defined(_WIN32) && !defined(BANDIT_CONFIG_COLOR_ANSI)
-#  ifndef NOMINMAX
-#    define NOMINMAX
-#  endif
-#  define WIN32_LEAN_AND_MEAN
-#  include <windows.h>
-#endif
+#include <bandit/colorizers/backend.h>
 
 namespace bandit {
   namespace detail {
-#if defined(_WIN32) && !defined(BANDIT_CONFIG_COLOR_ANSI)
-    struct colorizer {
-      colorizer(bool colors_enabled = true)
-          : colors_enabled_(colors_enabled),
-            stdout_handle_(GetStdHandle(STD_OUTPUT_HANDLE)) {
-        background_color_ = original_color_ = get_console_color();
-        background_color_ &= BACKGROUND_BLUE | BACKGROUND_GREEN | BACKGROUND_RED | BACKGROUND_INTENSITY;
-      }
+    struct colorizer : private bandit::colorizer::backend {
+      colorizer(bool colors_enabled = true) : backend(colors_enabled) {}
 
       const std::string green() const {
-        if (colors_enabled_) {
-          set_console_color(FOREGROUND_GREEN | FOREGROUND_INTENSITY | background_color_);
-        }
-        return "";
+        return backend::green();
       }
 
       const std::string yellow() const {
-        if (colors_enabled_) {
-          set_console_color(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY | background_color_);
-        }
-        return "";
+        return backend::yellow();
       }
 
       const std::string blue() const {
-        if (colors_enabled_) {
-          set_console_color(FOREGROUND_BLUE | FOREGROUND_INTENSITY | background_color_);
-        }
-        return "";
+        return backend::blue();
       }
 
       const std::string red() const {
-        if (colors_enabled_) {
-          set_console_color(FOREGROUND_RED | FOREGROUND_INTENSITY | background_color_);
-        }
-        return "";
+        return backend::red();
       }
 
       const std::string white() const {
-        if (colors_enabled_) {
-          set_console_color(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE |
-              FOREGROUND_INTENSITY | background_color_);
-        }
-        return "";
+        return backend::white();
       }
 
       const std::string reset() const {
-        if (colors_enabled_) {
-          set_console_color(original_color_);
-        }
-        return "";
+        return backend::reset();
       }
-
-    private:
-      WORD get_console_color() const {
-        CONSOLE_SCREEN_BUFFER_INFO info{};
-        GetConsoleScreenBufferInfo(stdout_handle_, &info);
-        return info.wAttributes;
-      }
-
-      void set_console_color(WORD color) const {
-        SetConsoleTextAttribute(stdout_handle_, color);
-      }
-
-    private:
-      bool colors_enabled_;
-      HANDLE stdout_handle_;
-      WORD original_color_;
-      WORD background_color_;
     };
-#else
-    struct colorizer {
-      colorizer(bool colors_enabled = true) : colors_enabled_(colors_enabled) {}
-
-      const std::string green() const {
-        return colors_enabled_ ? "\033[1;32m" : "";
-      }
-
-      const std::string yellow() const {
-        return colors_enabled_ ? "\033[1;33m" : "";
-      }
-
-      const std::string blue() const {
-        return colors_enabled_ ? "\033[1;34m" : "";
-      }
-
-      const std::string red() const {
-        return colors_enabled_ ? "\033[1;31m" : "";
-      }
-
-      const std::string white() const {
-        return colors_enabled_ ? "\033[1;37m" : "";
-      }
-
-      const std::string reset() const {
-        return colors_enabled_ ? "\033[0m" : "";
-      }
-
-    private:
-      bool colors_enabled_;
-    };
-#endif
   }
 }
 #endif

--- a/bandit/colorizers/colorizer.h
+++ b/bandit/colorizers/colorizer.h
@@ -2,40 +2,37 @@
 #define BANDIT_COLORIZERS_COLORIZER_H
 
 #include <bandit/colorizers/backend.h>
+#include <bandit/colorizers/interface.h>
 
 namespace bandit {
   namespace colorizer {
-    struct light : private backend {
+    struct light : interface, private backend {
       light(bool colors_enabled = true) : backend(colors_enabled) {}
 
-      const std::string good() const {
+      const std::string good() const override {
         return backend::green();
       }
 
-      const std::string neutral() const {
+      const std::string neutral() const override {
         return backend::yellow();
       }
 
-      const std::string info() const {
+      const std::string info() const override {
         return backend::blue();
       }
 
-      const std::string bad() const {
+      const std::string bad() const override {
         return backend::red();
       }
 
-      const std::string emphasize() const {
+      const std::string emphasize() const override {
         return backend::white();
       }
 
-      const std::string reset() const {
+      const std::string reset() const override {
         return backend::reset();
       }
     };
-  }
-
-  namespace detail {
-    using colorizer_t = ::bandit::colorizer::light;
   }
 }
 #endif

--- a/bandit/colorizers/colorizer.h
+++ b/bandit/colorizers/colorizer.h
@@ -4,27 +4,27 @@
 #include <bandit/colorizers/backend.h>
 
 namespace bandit {
-  namespace detail {
-    struct colorizer : private bandit::colorizer::backend {
-      colorizer(bool colors_enabled = true) : backend(colors_enabled) {}
+  namespace colorizer {
+    struct light : private backend {
+      light(bool colors_enabled = true) : backend(colors_enabled) {}
 
-      const std::string green() const {
+      const std::string good() const {
         return backend::green();
       }
 
-      const std::string yellow() const {
+      const std::string neutral() const {
         return backend::yellow();
       }
 
-      const std::string blue() const {
+      const std::string info() const {
         return backend::blue();
       }
 
-      const std::string red() const {
+      const std::string bad() const {
         return backend::red();
       }
 
-      const std::string white() const {
+      const std::string emphasize() const {
         return backend::white();
       }
 
@@ -32,6 +32,10 @@ namespace bandit {
         return backend::reset();
       }
     };
+  }
+
+  namespace detail {
+    using colorizer_t = ::bandit::colorizer::light;
   }
 }
 #endif

--- a/bandit/colorizers/dark.h
+++ b/bandit/colorizers/dark.h
@@ -1,0 +1,36 @@
+#ifndef BANDIT_COLORIZERS_DARK_H
+#define BANDIT_COLORIZERS_DARK_H
+
+#include <bandit/colorizers/backend.h>
+#include <bandit/colorizers/interface.h>
+
+namespace bandit {
+  namespace colorizer {
+    struct dark : interface, private backend {
+      const std::string good() const override {
+        return dark_green();
+      }
+
+      const std::string neutral() const override {
+        return brown();
+      }
+
+      const std::string info() const override {
+        return dark_blue();
+      }
+
+      const std::string bad() const override {
+        return dark_red();
+      }
+
+      const std::string emphasize() const override {
+        return dark_gray();
+      }
+
+      const std::string reset() const override {
+        return backend::reset();
+      }
+    };
+  }
+}
+#endif

--- a/bandit/colorizers/interface.h
+++ b/bandit/colorizers/interface.h
@@ -1,0 +1,22 @@
+#ifndef BANDIT_COLORIZERS_INTERFACE_H
+#define BANDIT_COLORIZERS_INTERFACE_H
+
+#include <string>
+
+namespace bandit {
+  namespace colorizer {
+    struct interface {
+      virtual const std::string good() const = 0;
+      virtual const std::string neutral() const = 0;
+      virtual const std::string info() const = 0;
+      virtual const std::string bad() const = 0;
+      virtual const std::string emphasize() const = 0;
+      virtual const std::string reset() const = 0;
+    };
+  }
+
+  namespace detail {
+    using colorizer_t = ::bandit::colorizer::interface;
+  }
+}
+#endif

--- a/bandit/colorizers/interface.h
+++ b/bandit/colorizers/interface.h
@@ -1,6 +1,7 @@
 #ifndef BANDIT_COLORIZERS_INTERFACE_H
 #define BANDIT_COLORIZERS_INTERFACE_H
 
+#include <memory>
 #include <string>
 
 namespace bandit {
@@ -17,6 +18,7 @@ namespace bandit {
 
   namespace detail {
     using colorizer_t = ::bandit::colorizer::interface;
+    using colorizer_ptr = std::unique_ptr<colorizer_t>;
   }
 }
 #endif

--- a/bandit/colorizers/light.h
+++ b/bandit/colorizers/light.h
@@ -8,23 +8,23 @@ namespace bandit {
   namespace colorizer {
     struct light : interface, private backend {
       const std::string good() const override {
-        return backend::green();
+        return green();
       }
 
       const std::string neutral() const override {
-        return backend::yellow();
+        return yellow();
       }
 
       const std::string info() const override {
-        return backend::blue();
+        return blue();
       }
 
       const std::string bad() const override {
-        return backend::red();
+        return red();
       }
 
       const std::string emphasize() const override {
-        return backend::white();
+        return white();
       }
 
       const std::string reset() const override {

--- a/bandit/colorizers/light.h
+++ b/bandit/colorizers/light.h
@@ -1,5 +1,5 @@
-#ifndef BANDIT_COLORIZERS_COLORIZER_H
-#define BANDIT_COLORIZERS_COLORIZER_H
+#ifndef BANDIT_COLORIZERS_LIGHT_H
+#define BANDIT_COLORIZERS_LIGHT_H
 
 #include <bandit/colorizers/backend.h>
 #include <bandit/colorizers/interface.h>

--- a/bandit/colorizers/off.h
+++ b/bandit/colorizers/off.h
@@ -1,34 +1,33 @@
-#ifndef BANDIT_COLORIZERS_LIGHT_H
-#define BANDIT_COLORIZERS_LIGHT_H
+#ifndef BANDIT_COLORIZERS_OFF_H
+#define BANDIT_COLORIZERS_OFF_H
 
-#include <bandit/colorizers/backend.h>
 #include <bandit/colorizers/interface.h>
 
 namespace bandit {
   namespace colorizer {
-    struct light : interface, private backend {
+    struct off : interface {
       const std::string good() const override {
-        return backend::green();
+        return "";
       }
 
       const std::string neutral() const override {
-        return backend::yellow();
+        return "";
       }
 
       const std::string info() const override {
-        return backend::blue();
+        return "";
       }
 
       const std::string bad() const override {
-        return backend::red();
+        return "";
       }
 
       const std::string emphasize() const override {
-        return backend::white();
+        return "";
       }
 
       const std::string reset() const override {
-        return backend::reset();
+        return "";
       }
     };
   }

--- a/bandit/options.h
+++ b/bandit/options.h
@@ -73,6 +73,7 @@ namespace bandit {
       enum class colorizers {
         OFF,
         LIGHT,
+        DARK,
         UNKNOWN
       };
 
@@ -115,6 +116,7 @@ namespace bandit {
           return {
               {colorizers::OFF, "off"},
               {colorizers::LIGHT, "light"},
+              {colorizers::DARK, "dark"},
           };
         }
 

--- a/bandit/options.h
+++ b/bandit/options.h
@@ -70,6 +70,12 @@ namespace bandit {
         };
       };
 
+      enum class colorizers {
+        OFF,
+        LIGHT,
+        UNKNOWN
+      };
+
       enum class formatters {
         POSIX,
         VS,
@@ -102,6 +108,13 @@ namespace bandit {
           return {
               {formatters::POSIX, "posix"},
               {formatters::VS, "vs"},
+          };
+        }
+
+        static const argstrs<colorizers> colorizer_list() {
+          return {
+              {colorizers::OFF, "off"},
+              {colorizers::LIGHT, "light"},
           };
         }
 
@@ -146,6 +159,10 @@ namespace bandit {
             status = option::ARG_ILLEGAL;
           }
           return status;
+        }
+
+        static option::ArgStatus Colorizer(const option::Option& option, bool msg) {
+          return OneOf(option, msg, colorizer_list());
         }
 
         static option::ArgStatus Reporter(const option::Option& option, bool msg) {
@@ -209,8 +226,8 @@ namespace bandit {
         return get_enumerator_from_string(argument::reporter_list(), options_[REPORTER].arg);
       }
 
-      bool no_color() const {
-        return options_[NO_COLOR] != nullptr;
+      colorizers colorizer() const {
+        return get_enumerator_from_string(argument::colorizer_list(), options_[COLORIZER].arg);
       }
 
       formatters formatter() const {
@@ -246,7 +263,7 @@ namespace bandit {
         VERSION,
         HELP,
         REPORTER,
-        NO_COLOR,
+        COLORIZER,
         FORMATTER,
         SKIP,
         ONLY,
@@ -262,6 +279,8 @@ namespace bandit {
       static const option::Descriptor* usage() {
         static std::string reporter_help = append_list("  --reporter=<reporter>, "
             "\tSelect reporter", argument::reporter_list());
+        static std::string colorizer_help = append_list("  --colorizer=<colorizer>, "
+            "\tSelect color theme", argument::colorizer_list());
         static std::string formatter_help = append_list("  --formatter=<formatter>, "
             "\tSelect error formatter", argument::formatter_list());
         static const option::Descriptor usage[] = {
@@ -273,8 +292,7 @@ namespace bandit {
             {HELP, 0, "", "help", argument::None,
                 "  --help, \tPrint usage and exit."},
             {REPORTER, 0, "", "reporter", argument::Reporter, reporter_help.c_str()},
-            {NO_COLOR, 0, "", "no-color", argument::None,
-                "  --no-color, \tSuppress colors in output"},
+            {COLORIZER, 0, "", "colorizer", argument::Colorizer, colorizer_help.c_str()},
             {FORMATTER, 0, "", "formatter", argument::Formatter, formatter_help.c_str()},
             {SKIP, 0, "", "skip", argument::Required,
                 "  --skip=<substring>, \tSkip all 'describe' and 'it' containing substring"},

--- a/bandit/reporters/colored_base.h
+++ b/bandit/reporters/colored_base.h
@@ -10,7 +10,7 @@ namespace bandit {
     struct colored_base : public progress_base {
       colored_base(std::ostream& stm,
           const detail::failure_formatter_t& formatter,
-          const detail::colorizer& colorizer)
+          const detail::colorizer_t& colorizer)
           : progress_base(formatter), stm_(stm), colorizer_(colorizer) {}
 
       ~colored_base() override {
@@ -19,7 +19,7 @@ namespace bandit {
 
     protected:
       std::ostream& stm_;
-      const detail::colorizer& colorizer_;
+      const detail::colorizer_t& colorizer_;
     };
   }
 }

--- a/bandit/reporters/colored_base.h
+++ b/bandit/reporters/colored_base.h
@@ -2,7 +2,7 @@
 #define BANDIT_REPORTERS_COLORED_BASE_H
 
 #include <ostream>
-#include <bandit/colorizers/colorizer.h>
+#include <bandit/colorizers.h>
 #include <bandit/reporters/progress_base.h>
 
 namespace bandit {

--- a/bandit/reporters/dots.h
+++ b/bandit/reporters/dots.h
@@ -8,10 +8,10 @@ namespace bandit {
   namespace reporter {
     struct dots : public colored_base {
       dots(std::ostream& stm, const detail::failure_formatter_t& formatter,
-          const detail::colorizer& colorizer)
+          const detail::colorizer_t& colorizer)
           : colored_base(stm, formatter, colorizer) {}
 
-      dots(const detail::failure_formatter_t& formatter, const detail::colorizer& colorizer)
+      dots(const detail::failure_formatter_t& formatter, const detail::colorizer_t& colorizer)
           : dots(std::cout, formatter, colorizer) {}
 
       dots& operator=(const dots&) {
@@ -40,25 +40,25 @@ namespace bandit {
 
       void it_succeeded(const std::string& desc) override {
         progress_base::it_succeeded(desc);
-        stm_ << colorizer_.green() << "." << colorizer_.reset();
+        stm_ << colorizer_.good() << "." << colorizer_.reset();
         stm_.flush();
       }
 
       void it_failed(const std::string& desc, const detail::assertion_exception& ex) override {
         progress_base::it_failed(desc, ex);
-        stm_ << colorizer_.red() << "F" << colorizer_.reset();
+        stm_ << colorizer_.bad() << "F" << colorizer_.reset();
         stm_.flush();
       }
 
       void it_skip(const std::string& desc) override {
         progress_base::it_skip(desc);
-        stm_ << colorizer_.yellow() << 'S' << colorizer_.reset();
+        stm_ << colorizer_.neutral() << 'S' << colorizer_.reset();
         stm_.flush();
       }
 
       void it_unknown_error(const std::string& desc) override {
         progress_base::it_unknown_error(desc);
-        stm_ << colorizer_.red() << "E" << colorizer_.reset();
+        stm_ << colorizer_.bad() << "E" << colorizer_.reset();
         stm_.flush();
       }
     };

--- a/bandit/reporters/info.h
+++ b/bandit/reporters/info.h
@@ -23,11 +23,11 @@ namespace bandit {
         int failed;
       };
 
-      info(std::ostream& stm, const detail::failure_formatter_t& formatter, const detail::colorizer& colorizer)
+      info(std::ostream& stm, const detail::failure_formatter_t& formatter, const detail::colorizer_t& colorizer)
           : colored_base(stm, formatter, colorizer),
             indentation_(0), not_yet_shown_(0), context_stack_() {}
 
-      info(const detail::failure_formatter_t& formatter, const detail::colorizer& colorizer)
+      info(const detail::failure_formatter_t& formatter, const detail::colorizer_t& colorizer)
           : info(std::cout, formatter, colorizer) {}
 
       info& operator=(const info&) {
@@ -37,27 +37,27 @@ namespace bandit {
       void list_failures_and_errors() {
         if (specs_failed_ > 0) {
           stm_
-              << colorizer_.red()
+              << colorizer_.bad()
               << "List of failures:"
               << std::endl;
           for (const auto& failure : failures_) {
             stm_
-                << colorizer_.white()
+                << colorizer_.emphasize()
                 << " (*) "
-                << colorizer_.red()
+                << colorizer_.bad()
                 << failure << std::endl;
           }
         }
         if (test_run_errors_.size() > 0) {
           stm_
-              << colorizer_.red()
+              << colorizer_.bad()
               << "List of run errors:"
               << std::endl;
           for (const auto& error : test_run_errors_) {
             stm_
-                << colorizer_.white()
+                << colorizer_.emphasize()
                 << " (*) "
-                << colorizer_.red()
+                << colorizer_.bad()
                 << error << std::endl;
           }
         }
@@ -65,30 +65,30 @@ namespace bandit {
 
       void summary() {
         stm_
-            << colorizer_.white()
+            << colorizer_.emphasize()
             << "Tests run: " << specs_run_
             << std::endl;
         if (specs_skipped_ > 0) {
           stm_
-              << colorizer_.yellow()
+              << colorizer_.neutral()
               << "Skipped: " << specs_skipped_
               << std::endl;
         }
         if (specs_succeeded_ > 0) {
           stm_
-              << colorizer_.green()
+              << colorizer_.good()
               << "Passed: " << specs_succeeded_
               << std::endl;
         }
         if (specs_failed_ > 0) {
           stm_
-              << colorizer_.red()
+              << colorizer_.bad()
               << "Failed: " << specs_failed_
               << std::endl;
         }
         if (test_run_errors_.size() > 0) {
           stm_
-              << colorizer_.red()
+              << colorizer_.bad()
               << "Errors: " << test_run_errors_.size()
               << std::endl;
         }
@@ -126,9 +126,9 @@ namespace bandit {
       void output_context_start_message() {
         stm_
             << indent()
-            << colorizer_.blue()
+            << colorizer_.info()
             << "begin "
-            << colorizer_.white()
+            << colorizer_.emphasize()
             << context_stack_.top().desc
             << colorizer_.reset()
             << std::endl;
@@ -170,23 +170,23 @@ namespace bandit {
         --indentation_;
         stm_
             << indent()
-            << colorizer_.blue()
+            << colorizer_.info()
             << "end "
             << colorizer_.reset()
             << context.desc;
         if (context.total > 0) {
           stm_
-              << colorizer_.white()
+              << colorizer_.emphasize()
               << " " << context.total << " total";
         }
         if (context.skipped > 0) {
           stm_
-              << colorizer_.yellow()
+              << colorizer_.neutral()
               << " " << context.skipped << " skipped";
         }
         if (context.failed > 0) {
           stm_
-              << colorizer_.red()
+              << colorizer_.bad()
               << " " << context.failed << " failed";
         }
         stm_ << colorizer_.reset() << std::endl;
@@ -206,7 +206,7 @@ namespace bandit {
         progress_base::it_starting(desc);
         stm_
             << indent()
-            << colorizer_.yellow()
+            << colorizer_.neutral()
             << "[ TEST ]"
             << colorizer_.reset()
             << " it " << desc;
@@ -220,7 +220,7 @@ namespace bandit {
         --indentation_;
         stm_
             << "\r" << indent()
-            << colorizer_.green()
+            << colorizer_.good()
             << "[ PASS ]"
             << colorizer_.reset()
             << " it " << desc
@@ -241,7 +241,7 @@ namespace bandit {
         --indentation_;
         stm_
             << "\r" << indent()
-            << colorizer_.red()
+            << colorizer_.bad()
             << "[ FAIL ]"
             << colorizer_.reset()
             << " it " << desc
@@ -261,7 +261,7 @@ namespace bandit {
         --indentation_;
         stm_
             << "\r" << indent()
-            << colorizer_.red()
+            << colorizer_.bad()
             << "-ERROR->"
             << colorizer_.reset()
             << " it " << desc

--- a/bandit/reporters/singleline.h
+++ b/bandit/reporters/singleline.h
@@ -8,11 +8,11 @@ namespace bandit {
   namespace reporter {
     struct singleline : public colored_base {
       singleline(std::ostream& stm, const detail::failure_formatter_t& formatter,
-          const detail::colorizer& colorizer)
+          const detail::colorizer_t& colorizer)
           : colored_base(stm, formatter, colorizer) {}
 
       singleline(const detail::failure_formatter_t& formatter,
-          const detail::colorizer& colorizer)
+          const detail::colorizer_t& colorizer)
           : singleline(std::cout, formatter, colorizer) {}
 
       singleline& operator=(const singleline&) {
@@ -66,7 +66,7 @@ namespace bandit {
         if (specs_failed_) {
           stm_
               << " " << specs_succeeded_ << " succeeded. "
-              << colorizer_.red() << specs_failed_ << " failed."
+              << colorizer_.bad() << specs_failed_ << " failed."
               << colorizer_.reset();
         }
         stm_.flush();

--- a/bandit/reporters/spec.h
+++ b/bandit/reporters/spec.h
@@ -8,10 +8,10 @@ namespace bandit {
   namespace reporter {
     struct spec : public colored_base {
       spec(std::ostream& stm, const detail::failure_formatter_t& formatter,
-          const detail::colorizer& colorizer)
+          const detail::colorizer_t& colorizer)
           : colored_base(stm, formatter, colorizer), indentation_(0) {}
 
-      spec(const detail::failure_formatter_t& formatter, const detail::colorizer& colorizer)
+      spec(const detail::failure_formatter_t& formatter, const detail::colorizer_t& colorizer)
           : spec(std::cout, formatter, colorizer) {}
 
       spec& operator=(const spec&) {
@@ -60,7 +60,7 @@ namespace bandit {
 
       void it_succeeded(const std::string& desc) override {
         progress_base::it_succeeded(desc);
-        stm_ << colorizer_.green();
+        stm_ << colorizer_.good();
         stm_ << "OK";
         stm_ << colorizer_.reset();
         stm_ << std::endl;
@@ -69,7 +69,7 @@ namespace bandit {
 
       void it_failed(const std::string& desc, const detail::assertion_exception& ex) override {
         progress_base::it_failed(desc, ex);
-        stm_ << colorizer_.red();
+        stm_ << colorizer_.bad();
         stm_ << "FAILED";
         stm_ << colorizer_.reset();
         stm_ << std::endl;
@@ -78,7 +78,7 @@ namespace bandit {
 
       void it_unknown_error(const std::string& desc) override {
         progress_base::it_unknown_error(desc);
-        stm_ << colorizer_.red();
+        stm_ << colorizer_.bad();
         stm_ << "ERROR";
         stm_ << colorizer_.reset();
         stm_ << std::endl;

--- a/bandit/reporters/summary.h
+++ b/bandit/reporters/summary.h
@@ -14,9 +14,9 @@ namespace bandit {
       static void write(std::ostream& stm,
           int specs_run, int specs_failed, int specs_succeeded, int specs_skipped,
           const std::list<std::string>& failures, const std::list<std::string>& errors,
-          const detail::colorizer& colorizer) {
+          const detail::colorizer_t& colorizer) {
         if (specs_run == 0 && errors.size() == 0) {
-          stm << colorizer.red()
+          stm << colorizer.bad()
               << "Could not find any tests."
               << colorizer.reset()
               << std::endl;
@@ -24,7 +24,7 @@ namespace bandit {
         }
 
         if (specs_failed == 0 && errors.size() == 0) {
-          stm << colorizer.green()
+          stm << colorizer.good()
               << "Success!"
               << colorizer.reset()
               << std::endl;
@@ -37,7 +37,7 @@ namespace bandit {
         }
 
         if (specs_failed > 0) {
-          stm << colorizer.red()
+          stm << colorizer.bad()
               << "There were failures!"
               << colorizer.reset() << std::endl;
           for (const auto& failure : failures) {

--- a/bandit/reporters/summary.h
+++ b/bandit/reporters/summary.h
@@ -4,7 +4,7 @@
 #include <algorithm>
 #include <list>
 #include <iostream>
-#include <bandit/colorizers/colorizer.h>
+#include <bandit/colorizers.h>
 
 namespace bandit {
   namespace reporter {

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -15,7 +15,7 @@ namespace bandit {
     }
 
     inline reporter_ptr create_reporter(const options& opt,
-        const failure_formatter_t* formatter, const colorizer& colorizer) {
+        const failure_formatter_t* formatter, const colorizer_t& colorizer) {
       switch (opt.reporter()) {
       case options::reporters::SINGLELINE:
         return reporter_ptr(new bandit::reporter::singleline(*formatter, colorizer));
@@ -82,7 +82,7 @@ namespace bandit {
       return 1;
     }
     detail::failure_formatter_ptr formatter(create_formatter(opt));
-    bandit::detail::colorizer colorizer(!opt.no_color());
+    detail::colorizer_t colorizer(!opt.no_color());
     detail::reporter_ptr reporter(create_reporter(opt, formatter.get(), colorizer));
 
     detail::register_reporter(reporter.get());

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -82,7 +82,7 @@ namespace bandit {
       return 1;
     }
     detail::failure_formatter_ptr formatter(create_formatter(opt));
-    detail::colorizer_t colorizer(!opt.no_color());
+    colorizer::light colorizer(!opt.no_color());
     detail::reporter_ptr reporter(create_reporter(opt, formatter.get(), colorizer));
 
     detail::register_reporter(reporter.get());

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -47,10 +47,13 @@ namespace bandit {
     }
 
     inline colorizer_ptr create_colorizer(const options& opt) {
-      if (opt.no_color()) {
+      switch (opt.colorizer()) {
+      case options::colorizers::OFF:
         return colorizer_ptr(new colorizer::off());
+      case options::colorizers::LIGHT:
+      default:
+        return colorizer_ptr(new colorizer::light());
       }
-      return colorizer_ptr(new colorizer::light());
     }
   }
 

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -15,21 +15,21 @@ namespace bandit {
     }
 
     inline reporter_ptr create_reporter(const options& opt,
-        const failure_formatter_t* formatter, const colorizer_t& colorizer) {
+        const failure_formatter_t& formatter, const colorizer_t& colorizer) {
       switch (opt.reporter()) {
       case options::reporters::SINGLELINE:
-        return reporter_ptr(new bandit::reporter::singleline(*formatter, colorizer));
+        return reporter_ptr(new bandit::reporter::singleline(formatter, colorizer));
       case options::reporters::XUNIT:
-        return reporter_ptr(new bandit::reporter::xunit(*formatter));
+        return reporter_ptr(new bandit::reporter::xunit(formatter));
       case options::reporters::INFO:
-        return reporter_ptr(new bandit::reporter::info(*formatter, colorizer));
+        return reporter_ptr(new bandit::reporter::info(formatter, colorizer));
       case options::reporters::SPEC:
-        return reporter_ptr(new bandit::reporter::spec(*formatter, colorizer));
+        return reporter_ptr(new bandit::reporter::spec(formatter, colorizer));
       case options::reporters::CRASH:
-        return reporter_ptr(new bandit::reporter::crash(*formatter));
+        return reporter_ptr(new bandit::reporter::crash(formatter));
       case options::reporters::DOTS:
       default:
-        return reporter_ptr(new bandit::reporter::dots(*formatter, colorizer));
+        return reporter_ptr(new bandit::reporter::dots(formatter, colorizer));
       }
     }
 
@@ -91,9 +91,10 @@ namespace bandit {
 
     detail::failure_formatter_ptr formatter(create_formatter(opt));
     detail::colorizer_ptr colorizer(create_colorizer(opt));
-    detail::reporter_ptr reporter(create_reporter(opt, formatter.get(), *colorizer));
+    detail::reporter_ptr reporter(create_reporter(opt, *formatter, *colorizer));
+    detail::run_policy_ptr run_policy(create_run_policy(opt));
+
     detail::register_reporter(reporter.get());
-    detail::run_policy_ptr run_policy = create_run_policy(opt);
     detail::register_run_policy(run_policy.get());
 
     return run(opt, detail::specs(), context::stack(), *reporter);

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -50,6 +50,8 @@ namespace bandit {
       switch (opt.colorizer()) {
       case options::colorizers::OFF:
         return colorizer_ptr(new colorizer::off());
+      case options::colorizers::DARK:
+        return colorizer_ptr(new colorizer::dark());
       case options::colorizers::LIGHT:
       default:
         return colorizer_ptr(new colorizer::light());

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -45,6 +45,13 @@ namespace bandit {
         return failure_formatter_ptr(new failure_formatter::posix());
       }
     }
+
+    inline colorizer_ptr create_colorizer(const options& opt) {
+      if (opt.no_color()) {
+        return colorizer_ptr(new colorizer::off());
+      }
+      return colorizer_ptr(new colorizer::light());
+    }
   }
 
   inline int run(const detail::options& opt, const detail::spec_registry& specs,
@@ -81,12 +88,11 @@ namespace bandit {
       opt.print_usage();
       return 1;
     }
+
     detail::failure_formatter_ptr formatter(create_formatter(opt));
-    colorizer::light colorizer(!opt.no_color());
-    detail::reporter_ptr reporter(create_reporter(opt, formatter.get(), colorizer));
-
+    detail::colorizer_ptr colorizer(create_colorizer(opt));
+    detail::reporter_ptr reporter(create_reporter(opt, formatter.get(), *colorizer));
     detail::register_reporter(reporter.get());
-
     detail::run_policy_ptr run_policy = create_run_policy(opt);
     detail::register_run_policy(run_policy.get());
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -11,6 +11,9 @@ In the following, we list breaking changes per major release.
 
 * The `default` formatter is renamed to `posix`.
 
+* The `--no-color` option is replaced by `--colorizer=off`. It now can be
+  understood as choosing the `off` color theme instead of turning colors off.
+
 * In prior versions, an error was raised in case no tests were available
   or all tests were skipped. Now the exit code is `0` in these cases because
   no tests are failing.

--- a/docs/runningtests.md
+++ b/docs/runningtests.md
@@ -19,7 +19,7 @@ Options:
   --help,                  Print usage and exit.
   --reporter=<reporter>,   Select reporter: crash, dots, singleline, xunit,
                            info, spec
-  --no-color,              Suppress colors in output
+  --colorizer=<colorizer>, Select color theme: off, light
   --formatter=<formatter>, Select error formatter: posix, vs
   --skip=<substring>,      Skip all 'describe' and 'it' containing substring
   --only=<substring>,      Run only 'describe' and 'it' containing substring
@@ -124,7 +124,7 @@ errors to be reported, as
 
 By default, bandit uses colors to highlight the status of the current test run.
 In certain IDEs or when running tests in continuous integration environment, this
-may look ugly. By specifying `--no-color` you can tell bandit to stop using colors.
+may look ugly. By specifying `--colorizer=off` you can tell bandit to stop using colors.
 
 ## Tweaking the behavior
 

--- a/docs/runningtests.md
+++ b/docs/runningtests.md
@@ -19,7 +19,7 @@ Options:
   --help,                  Print usage and exit.
   --reporter=<reporter>,   Select reporter: crash, dots, singleline, xunit,
                            info, spec
-  --colorizer=<colorizer>, Select color theme: off, light
+  --colorizer=<colorizer>, Select color theme: off, light, dark
   --formatter=<formatter>, Select error formatter: posix, vs
   --skip=<substring>,      Skip all 'describe' and 'it' containing substring
   --only=<substring>,      Run only 'describe' and 'it' containing substring
@@ -122,9 +122,23 @@ errors to be reported, as
 
 ### Colors
 
-By default, bandit uses colors to highlight the status of the current test run.
-In certain IDEs or when running tests in continuous integration environment, this
-may look ugly. By specifying `--colorizer=off` you can tell bandit to stop using colors.
+Bandit uses colors to highlight the status of the current test run.
+
+#### `--colorizer=off`
+
+Turns colors off.
+In certain IDEs or when running tests in continuous integration environment,
+colors might be ugly or are not supported and you just see the underlying escape
+sequences.
+
+#### `--colorizer=light`
+
+Uses a color theme with light colors for dark backgrounds.
+This is the default.
+
+#### `--colorizer=dark`
+
+Uses a color theme with dark colors for light backgrounds.
 
 ## Tweaking the behavior
 

--- a/specs/colorizer.cpp
+++ b/specs/colorizer.cpp
@@ -4,30 +4,31 @@ go_bandit([]() {
   describe("colorizers", [&]() {
 #if !defined(_WIN32) || defined(BANDIT_CONFIG_COLOR_ANSI)
     describe("colorizer::light", [&]() {
+      colorizer::backend color;
       colorizer::light colorizer;
 
       it("sets 'bad' color to red", [&]() {
-        AssertThat(colorizer.bad(), Equals("\033[1;31m"));
+        AssertThat(colorizer.bad(), Equals(color.red()));
       });
 
       it("sets 'good' color to green", [&]() {
-        AssertThat(colorizer.good(), Equals("\033[1;32m"));
+        AssertThat(colorizer.good(), Equals(color.green()));
       });
 
       it("sets 'neutral' color to yellow", [&]() {
-        AssertThat(colorizer.neutral(), Equals("\033[1;33m"));
+        AssertThat(colorizer.neutral(), Equals(color.yellow()));
       });
 
       it("sets 'info' color to blue", [&]() {
-        AssertThat(colorizer.info(), Equals("\033[1;34m"));
+        AssertThat(colorizer.info(), Equals(color.blue()));
       });
 
       it("emphasizes using color white", [&]() {
-        AssertThat(colorizer.emphasize(), Equals("\033[1;37m"));
+        AssertThat(colorizer.emphasize(), Equals(color.white()));
       });
 
       it("resets color", [&]() {
-        AssertThat(colorizer.reset(), Equals("\033[0m"));
+        AssertThat(colorizer.reset(), Equals(color.reset()));
       });
     });
 
@@ -65,27 +66,27 @@ go_bandit([]() {
       colorizer::off colorizer;
 
       it("ignores setting 'good' color", [&]() {
-        AssertThat(colorizer.good(), Equals(""));
+        AssertThat(colorizer.good(), IsEmpty());
       });
 
       it("ignores setting 'bad' color", [&]() {
-        AssertThat(colorizer.bad(), Equals(""));
+        AssertThat(colorizer.bad(), IsEmpty());
       });
 
       it("ignores setting 'neutral' color", [&]() {
-        AssertThat(colorizer.good(), Equals(""));
+        AssertThat(colorizer.good(), IsEmpty());
       });
 
       it("ignores setting 'info' color", [&]() {
-        AssertThat(colorizer.good(), Equals(""));
+        AssertThat(colorizer.good(), IsEmpty());
       });
 
       it("ignores emphasizing", [&]() {
-        AssertThat(colorizer.good(), Equals(""));
+        AssertThat(colorizer.good(), IsEmpty());
       });
 
       it("ignores resetting colors", [&]() {
-        AssertThat(colorizer.reset(), Equals(""));
+        AssertThat(colorizer.reset(), IsEmpty());
       });
     });
   });

--- a/specs/colorizer.cpp
+++ b/specs/colorizer.cpp
@@ -30,6 +30,35 @@ go_bandit([]() {
         AssertThat(colorizer.reset(), Equals("\033[0m"));
       });
     });
+
+    describe("colorizer::dark", [&]() {
+      colorizer::backend color;
+      colorizer::dark colorizer;
+
+      it("sets 'bad' color to dark red", [&]() {
+        AssertThat(colorizer.bad(), Equals(color.dark_red()));
+      });
+
+      it("sets 'good' color to dark green", [&]() {
+        AssertThat(colorizer.good(), Equals(color.dark_green()));
+      });
+
+      it("sets 'neutral' color to brown", [&]() {
+        AssertThat(colorizer.neutral(), Equals(color.brown()));
+      });
+
+      it("sets 'info' color to dark blue", [&]() {
+        AssertThat(colorizer.info(), Equals(color.dark_blue()));
+      });
+
+      it("emphasizes using color dark gray", [&]() {
+        AssertThat(colorizer.emphasize(), Equals(color.dark_gray()));
+      });
+
+      it("resets color", [&]() {
+        AssertThat(colorizer.reset(), Equals(color.reset()));
+      });
+    });
 #endif
 
     describe("colorizer::off", [&]() {

--- a/specs/colorizer.cpp
+++ b/specs/colorizer.cpp
@@ -1,18 +1,19 @@
 #include <specs/specs.h>
 
 go_bandit([]() {
-  describe("colorizer", [&]() {
+  describe("colorizer::light", [&]() {
 #if !defined(_WIN32) || defined(BANDIT_CONFIG_COLOR_ANSI)
     describe("colors enabled", [&]() {
-      bandit::detail::colorizer colorizer;
+      colorizer::light colorizer;
 
-      it("can set color to green", [&]() {
-        AssertThat(colorizer.green(), Equals("\033[1;32m"));
+      it("sets 'good' color to green", [&]() {
+        AssertThat(colorizer.good(), Equals("\033[1;32m"));
       });
 
-      it("set color to red", [&]() {
-        AssertThat(colorizer.red(), Equals("\033[1;31m"));
+      it("sets 'bad' color to red", [&]() {
+        AssertThat(colorizer.bad(), Equals("\033[1;31m"));
       });
+
       it("resets color", [&]() {
         AssertThat(colorizer.reset(), Equals("\033[0m"));
       });
@@ -20,14 +21,14 @@ go_bandit([]() {
 #endif
 
     describe("colors disabled", [&]() {
-      bandit::detail::colorizer colorizer(false);
+      colorizer::light colorizer(false);
 
-      it("ignores setting color to green", [&]() {
-        AssertThat(colorizer.green(), Equals(""));
+      it("ignores setting 'good' color", [&]() {
+        AssertThat(colorizer.good(), Equals(""));
       });
 
-      it("ignores setting color to red", [&]() {
-        AssertThat(colorizer.red(), Equals(""));
+      it("ignores setting 'bad' color", [&]() {
+        AssertThat(colorizer.bad(), Equals(""));
       });
 
       it("ignores resetting colors", [&]() {

--- a/specs/colorizer.cpp
+++ b/specs/colorizer.cpp
@@ -6,12 +6,24 @@ go_bandit([]() {
     describe("colorizer::light", [&]() {
       colorizer::light colorizer;
 
+      it("sets 'bad' color to red", [&]() {
+        AssertThat(colorizer.bad(), Equals("\033[1;31m"));
+      });
+
       it("sets 'good' color to green", [&]() {
         AssertThat(colorizer.good(), Equals("\033[1;32m"));
       });
 
-      it("sets 'bad' color to red", [&]() {
-        AssertThat(colorizer.bad(), Equals("\033[1;31m"));
+      it("sets 'neutral' color to yellow", [&]() {
+        AssertThat(colorizer.neutral(), Equals("\033[1;33m"));
+      });
+
+      it("sets 'info' color to blue", [&]() {
+        AssertThat(colorizer.info(), Equals("\033[1;34m"));
+      });
+
+      it("emphasizes using color white", [&]() {
+        AssertThat(colorizer.emphasize(), Equals("\033[1;37m"));
       });
 
       it("resets color", [&]() {
@@ -29,6 +41,18 @@ go_bandit([]() {
 
       it("ignores setting 'bad' color", [&]() {
         AssertThat(colorizer.bad(), Equals(""));
+      });
+
+      it("ignores setting 'neutral' color", [&]() {
+        AssertThat(colorizer.good(), Equals(""));
+      });
+
+      it("ignores setting 'info' color", [&]() {
+        AssertThat(colorizer.good(), Equals(""));
+      });
+
+      it("ignores emphasizing", [&]() {
+        AssertThat(colorizer.good(), Equals(""));
       });
 
       it("ignores resetting colors", [&]() {

--- a/specs/colorizer.cpp
+++ b/specs/colorizer.cpp
@@ -1,9 +1,9 @@
 #include <specs/specs.h>
 
 go_bandit([]() {
-  describe("colorizer::light", [&]() {
+  describe("colorizers", [&]() {
 #if !defined(_WIN32) || defined(BANDIT_CONFIG_COLOR_ANSI)
-    describe("colors enabled", [&]() {
+    describe("colorizer::light", [&]() {
       colorizer::light colorizer;
 
       it("sets 'good' color to green", [&]() {
@@ -20,8 +20,8 @@ go_bandit([]() {
     });
 #endif
 
-    describe("colors disabled", [&]() {
-      colorizer::light colorizer(false);
+    describe("colorizer::off", [&]() {
+      colorizer::off colorizer;
 
       it("ignores setting 'good' color", [&]() {
         AssertThat(colorizer.good(), Equals(""));

--- a/specs/options.cpp
+++ b/specs/options.cpp
@@ -78,12 +78,6 @@ go_bandit([]() {
         all_ok(opt);
       });
 
-      it("parses the '--no-color' option", [&]() {
-        options opt({"--no-color"});
-        AssertThat(opt.no_color(), IsTrue());
-        all_ok(opt);
-      });
-
       it("parses the '--skip=\"substring\"' option once", [&]() {
         options opt({"--skip=substring"});
         AssertThat(opt.filter_chain(), HasLength(1));
@@ -148,10 +142,6 @@ go_bandit([]() {
         AssertThat(opt.version(), IsFalse());
       });
 
-      it("cannot find '--no-color'", [&]() {
-        AssertThat(opt.no_color(), IsFalse());
-      });
-
       it("cannot find '--break-on-failure'", [&]() {
         AssertThat(opt.break_on_failure(), IsFalse());
       });
@@ -185,11 +175,10 @@ go_bandit([]() {
 
       it("ignores unknown options and arguments", [&] {
         options opt({"--unknown-option", "--formatter=vs", "--reporter", "xunit",
-            "--no-color", "unknown-argument", "--dry-run"});
+            "unknown-argument", "--dry-run"});
         AssertThat(opt.parsed_ok(), IsTrue());
         AssertThat(opt.formatter(), Equals(bd::options::formatters::VS));
         AssertThat(opt.reporter(), Equals(bd::options::reporters::XUNIT));
-        AssertThat(opt.no_color(), IsTrue());
         AssertThat(opt.dry_run(), IsFalse());
         AssertThat(opt.has_further_arguments(), IsTrue());
         AssertThat(opt.has_unknown_options(), IsTrue());
@@ -213,6 +202,13 @@ go_bandit([]() {
             {"xunit", bd::options::reporters::XUNIT},
           }, [&](const bd::options& opt) {
             return opt.reporter();
+          });
+      choice_tests<bd::options::colorizers>("colorizer",
+          bd::options::colorizers::UNKNOWN, {
+            {"off", bd::options::colorizers::OFF},
+            {"light", bd::options::colorizers::LIGHT},
+          }, [&](const bd::options& opt) {
+            return opt.colorizer();
           });
     });
 

--- a/specs/reporters/dots.cpp
+++ b/specs/reporters/dots.cpp
@@ -6,7 +6,7 @@ go_bandit([]() {
     std::stringstream stm;
     std::unique_ptr<reporter::dots> reporter;
     failure_formatter::posix formatter;
-    bd::colorizer_t colorizer(false);
+    colorizer::light colorizer(false);
 
     before_each([&]() {
       stm.str(std::string());

--- a/specs/reporters/dots.cpp
+++ b/specs/reporters/dots.cpp
@@ -6,7 +6,7 @@ go_bandit([]() {
     std::stringstream stm;
     std::unique_ptr<reporter::dots> reporter;
     failure_formatter::posix formatter;
-    colorizer::light colorizer(false);
+    colorizer::off colorizer;
 
     before_each([&]() {
       stm.str(std::string());

--- a/specs/reporters/dots.cpp
+++ b/specs/reporters/dots.cpp
@@ -6,7 +6,7 @@ go_bandit([]() {
     std::stringstream stm;
     std::unique_ptr<reporter::dots> reporter;
     failure_formatter::posix formatter;
-    bd::colorizer colorizer(false);
+    bd::colorizer_t colorizer(false);
 
     before_each([&]() {
       stm.str(std::string());

--- a/specs/reporters/info.cpp
+++ b/specs/reporters/info.cpp
@@ -6,7 +6,7 @@ go_bandit([]() {
     std::stringstream stm;
     std::unique_ptr<reporter::info> reporter;
     failure_formatter::posix formatter;
-    colorizer::light colorizer(false);
+    colorizer::off colorizer;
 
     before_each([&]() {
       stm.str(std::string());

--- a/specs/reporters/info.cpp
+++ b/specs/reporters/info.cpp
@@ -6,7 +6,7 @@ go_bandit([]() {
     std::stringstream stm;
     std::unique_ptr<reporter::info> reporter;
     failure_formatter::posix formatter;
-    bd::colorizer_t colorizer(false);
+    colorizer::light colorizer(false);
 
     before_each([&]() {
       stm.str(std::string());

--- a/specs/reporters/info.cpp
+++ b/specs/reporters/info.cpp
@@ -6,7 +6,7 @@ go_bandit([]() {
     std::stringstream stm;
     std::unique_ptr<reporter::info> reporter;
     failure_formatter::posix formatter;
-    bd::colorizer colorizer(false);
+    bd::colorizer_t colorizer(false);
 
     before_each([&]() {
       stm.str(std::string());

--- a/specs/reporters/singleline.cpp
+++ b/specs/reporters/singleline.cpp
@@ -6,7 +6,7 @@ go_bandit([]() {
     std::stringstream stm;
     std::unique_ptr<reporter::singleline> reporter;
     failure_formatter::posix formatter;
-    colorizer::light colorizer(false);
+    colorizer::off colorizer;
 
     before_each([&]() {
       stm.str(std::string());

--- a/specs/reporters/singleline.cpp
+++ b/specs/reporters/singleline.cpp
@@ -6,7 +6,7 @@ go_bandit([]() {
     std::stringstream stm;
     std::unique_ptr<reporter::singleline> reporter;
     failure_formatter::posix formatter;
-    bd::colorizer_t colorizer(false);
+    colorizer::light colorizer(false);
 
     before_each([&]() {
       stm.str(std::string());

--- a/specs/reporters/singleline.cpp
+++ b/specs/reporters/singleline.cpp
@@ -6,7 +6,7 @@ go_bandit([]() {
     std::stringstream stm;
     std::unique_ptr<reporter::singleline> reporter;
     failure_formatter::posix formatter;
-    bd::colorizer colorizer(false);
+    bd::colorizer_t colorizer(false);
 
     before_each([&]() {
       stm.str(std::string());


### PR DESCRIPTION
This merge request introduces a colorizer interface, replaces the
default coloring by the `light` colorizer and the disabled colors (using
the `--no-color` option that is now removed) by the `off` colorizer,
and finally adds a `dark` colorizer for light backgrounds.

This should fix #90, at least to some extent.