### PR TITLE
Introduce controller_t and rework options

### DIFF
--- a/bandit/adapters.h
+++ b/bandit/adapters.h
@@ -3,12 +3,4 @@
 
 #include <bandit/adapters/snowhouse.h>
 
-namespace bandit {
-  namespace detail {
-    inline assertion_adapter_t& registered_adapter() {
-      static adapter::snowhouse default_adapter;
-      return default_adapter;
-    }
-  }
-}
 #endif

--- a/bandit/adapters/interface.h
+++ b/bandit/adapters/interface.h
@@ -13,7 +13,6 @@ namespace bandit {
 
   namespace detail {
     using assertion_adapter_t = adapter::interface;
-    using assertion_adapter_ptr = std::unique_ptr<assertion_adapter_t>;
   }
 }
 #endif

--- a/bandit/adapters/interface.h
+++ b/bandit/adapters/interface.h
@@ -2,6 +2,7 @@
 #define BANDIT_ADAPTERS_INTERFACE_H
 
 #include <functional>
+#include <memory>
 
 namespace bandit {
   namespace adapter {
@@ -12,6 +13,7 @@ namespace bandit {
 
   namespace detail {
     using assertion_adapter_t = adapter::interface;
+    using assertion_adapter_ptr = std::unique_ptr<assertion_adapter_t>;
   }
 }
 #endif

--- a/bandit/adapters/interface.h
+++ b/bandit/adapters/interface.h
@@ -2,7 +2,6 @@
 #define BANDIT_ADAPTERS_INTERFACE_H
 
 #include <functional>
-#include <memory>
 
 namespace bandit {
   namespace adapter {

--- a/bandit/colorizers/interface.h
+++ b/bandit/colorizers/interface.h
@@ -18,7 +18,6 @@ namespace bandit {
 
   namespace detail {
     using colorizer_t = ::bandit::colorizer::interface;
-    using colorizer_ptr = std::unique_ptr<colorizer_t>;
   }
 }
 #endif

--- a/bandit/colorizers/interface.h
+++ b/bandit/colorizers/interface.h
@@ -1,7 +1,6 @@
 #ifndef BANDIT_COLORIZERS_INTERFACE_H
 #define BANDIT_COLORIZERS_INTERFACE_H
 
-#include <memory>
 #include <string>
 
 namespace bandit {

--- a/bandit/context.h
+++ b/bandit/context.h
@@ -82,11 +82,6 @@ namespace bandit {
         }
       }
     };
-
-    inline stack_t& stack() {
-      static stack_t contexts;
-      return contexts;
-    }
   }
 }
 #endif

--- a/bandit/context.h
+++ b/bandit/context.h
@@ -75,7 +75,13 @@ namespace bandit {
       std::list<std::function<void()>> after_eaches_;
     };
 
-    using stack_t = std::deque<context::interface*>;
+    struct stack_t : public std::deque<context::interface*> {
+      void throw_if_empty(std::string&& method) const {
+        if (empty()) {
+          throw detail::test_run_error("'" + method + "' was called without surrounding 'describe'");
+        }
+      }
+    };
 
     inline stack_t& stack() {
       static stack_t contexts;

--- a/bandit/controller.h
+++ b/bandit/controller.h
@@ -1,5 +1,5 @@
-#ifndef BANDIT_SETTINGS_H
-#define BANDIT_SETTINGS_H
+#ifndef BANDIT_CONTROLLER_H
+#define BANDIT_CONTROLLER_H
 
 #include <bandit/adapters.h>
 #include <bandit/colorizers/interface.h>
@@ -9,15 +9,15 @@
 
 namespace bandit {
   namespace detail {
-    struct settings_t {
-      settings_t() : adapter(new adapter::snowhouse) {}
+    struct controller_t {
+      controller_t() : adapter(new adapter::snowhouse) {}
 
       context::stack_t& get_contexts() {
         return context_stack;
       }
 
       assertion_adapter_t& get_adapter() {
-        throw_if_nullptr(adapter.get(), "assertion adapter", "bandit::detail::settings_t::set_adapter()");
+        throw_if_nullptr(adapter.get(), "assertion adapter", "bandit::detail::controller_t::set_adapter()");
         return *adapter;
       }
 
@@ -26,7 +26,7 @@ namespace bandit {
       }
 
       colorizer_t& get_colorizer() {
-        throw_if_nullptr(colorizer.get(), "colorizer", "bandit::detail::settings_t::set_colorizer()");
+        throw_if_nullptr(colorizer.get(), "colorizer", "bandit::detail::controller_t::set_colorizer()");
         return *colorizer;
       }
 
@@ -35,7 +35,7 @@ namespace bandit {
       }
 
       failure_formatter_t& get_formatter() {
-        throw_if_nullptr(formatter.get(), "formatter", "bandit::detail::settings_t::set_formatter()");
+        throw_if_nullptr(formatter.get(), "formatter", "bandit::detail::controller_t::set_formatter()");
         return *formatter;
       }
 
@@ -44,7 +44,7 @@ namespace bandit {
       }
 
       reporter_t& get_reporter() {
-        throw_if_nullptr(reporter.get(), "reporter", "bandit::detail::settings_t::set_reporter()");
+        throw_if_nullptr(reporter.get(), "reporter", "bandit::detail::controller_t::set_reporter()");
         return *reporter;
       }
 
@@ -53,7 +53,7 @@ namespace bandit {
       }
 
       run_policy_t& get_policy() {
-        throw_if_nullptr(run_policy.get(), "run policy", "bandit::detail::settings_t::set_policy()");
+        throw_if_nullptr(run_policy.get(), "run policy", "bandit::detail::controller_t::set_policy()");
         return *run_policy;
       }
 
@@ -128,25 +128,25 @@ namespace bandit {
         }
       }
 
-      // A function is required to initialize a static settings variable in a header file
+      // A function is required to initialize a static controller variable in a header file
       // and this struct aims at encapsulating this function
-      static void register_settings(settings_t* settings) {
-        if (settings == nullptr) {
-          throw std::runtime_error("Invalid null settings passed to bandit::detail::register_settings()");
+      static void register_controller(controller_t* controller) {
+        if (controller == nullptr) {
+          throw std::runtime_error("Invalid null controller passed to bandit::detail::register_controller()");
         }
-        get_settings_address() = settings;
+        get_controller_address() = controller;
       }
 
-      static settings_t& registered_settings() {
-        auto settings = get_settings_address();
-        throw_if_nullptr(settings, "settings", "bandit::detail::register_settings()");
-        return *settings;
+      static controller_t& registered_controller() {
+        auto controller = get_controller_address();
+        throw_if_nullptr(controller, "controller", "bandit::detail::register_controller()");
+        return *controller;
       }
 
     private:
-      static settings_t*& get_settings_address() {
-        static settings_t* settings_ = nullptr;
-        return settings_;
+      static controller_t*& get_controller_address() {
+        static controller_t* controller_ = nullptr;
+        return controller_;
       }
 
       static void throw_if_nullptr(const void* ptr, const std::string& name, const std::string& setter) {
@@ -187,12 +187,12 @@ namespace bandit {
       std::unique_ptr<run_policy_t> run_policy;
     };
 
-    inline void register_settings(settings_t* settings) {
-      settings_t::register_settings(settings);
+    inline void register_controller(controller_t* controller) {
+      controller_t::register_controller(controller);
     }
 
-    inline settings_t& registered_settings() {
-      return settings_t::registered_settings();
+    inline controller_t& registered_controller() {
+      return controller_t::registered_controller();
     }
   }
 }

--- a/bandit/controller.h
+++ b/bandit/controller.h
@@ -1,6 +1,7 @@
 #ifndef BANDIT_CONTROLLER_H
 #define BANDIT_CONTROLLER_H
 
+#include <memory>
 #include <bandit/adapters.h>
 #include <bandit/colorizers/interface.h>
 #include <bandit/failure_formatters/interface.h>

--- a/bandit/failure_formatters.h
+++ b/bandit/failure_formatters.h
@@ -4,12 +4,4 @@
 #include "failure_formatters/posix.h"
 #include "failure_formatters/visual_studio.h"
 
-namespace bandit {
-  namespace detail {
-    inline failure_formatter_t& registered_failure_formatter() {
-      static failure_formatter::posix default_formatter;
-      return default_formatter;
-    }
-  }
-}
 #endif

--- a/bandit/failure_formatters/interface.h
+++ b/bandit/failure_formatters/interface.h
@@ -1,7 +1,6 @@
 #ifndef BANDIT_FAILURE_FORMATTERS_INTERFACE_H
 #define BANDIT_FAILURE_FORMATTERS_INTERFACE_H
 
-#include <memory>
 #include <bandit/assertion_exception.h>
 
 namespace bandit {

--- a/bandit/failure_formatters/interface.h
+++ b/bandit/failure_formatters/interface.h
@@ -13,7 +13,6 @@ namespace bandit {
 
   namespace detail {
     using failure_formatter_t = ::bandit::failure_formatter::interface;
-    using failure_formatter_ptr = std::unique_ptr<failure_formatter_t>;
   }
 }
 #endif

--- a/bandit/grammar.h
+++ b/bandit/grammar.h
@@ -85,11 +85,12 @@ namespace bandit {
     it_skip(desc, func, reporter);
   }
 
-  inline void it(const std::string& desc, std::function<void()> func, detail::reporter_t& reporter,
+  inline void it(const std::string& desc, std::function<void()> func, detail::settings_t& settings,
       context::stack_t& context_stack,
-      detail::assertion_adapter_t& assertion_adapter,
-      detail::run_policy_t& run_policy,
       bool hard_skip = false) {
+    detail::reporter_t& reporter = settings.get_reporter();
+    detail::assertion_adapter_t& assertion_adapter = settings.get_adapter();
+    detail::run_policy_t& run_policy = settings.get_policy();
     throw_if_no_context("it", context_stack);
     if (hard_skip || !run_policy.should_run(desc, context_stack)) {
       it_skip(desc, func, reporter);
@@ -154,10 +155,7 @@ namespace bandit {
   }
 
   inline void it(const std::string& desc, std::function<void()> func, bool hard_skip = false) {
-    it(desc, func, detail::registered_settings().get_reporter(), context::stack(),
-        detail::registered_settings().get_adapter(),
-        detail::registered_settings().get_policy(),
-        hard_skip);
+    it(desc, func, detail::registered_settings(), context::stack(), hard_skip);
   }
 }
 #endif

--- a/bandit/grammar.h
+++ b/bandit/grammar.h
@@ -5,26 +5,19 @@
 
 namespace bandit {
   inline void describe(const std::string& desc, std::function<void()> func,
-      detail::settings_t& settings, bool hard_skip = false) {
+      bool hard_skip = false,
+      detail::settings_t& settings = detail::registered_settings()) {
     settings.describe(desc, func, hard_skip);
   }
 
-  inline void describe(const std::string& desc, std::function<void()> func, bool hard_skip = false) {
-    describe(desc, func, detail::registered_settings(), hard_skip);
-  }
-
   inline void describe_skip(const std::string& desc, std::function<void()> func,
-      detail::settings_t& settings) {
-    describe(desc, func, settings, true);
-  }
-
-  inline void describe_skip(const std::string& desc, std::function<void()> func) {
-    describe_skip(desc, func, detail::registered_settings());
+      detail::settings_t& settings = detail::registered_settings()) {
+    describe(desc, func, true, settings);
   }
 
   inline void xdescribe(const std::string& desc, std::function<void()> func,
       detail::settings_t& settings = detail::registered_settings()) {
-    describe_skip(desc, func, settings);
+    describe(desc, func, true, settings);
   }
 
   inline void before_each(std::function<void()> func,
@@ -37,26 +30,19 @@ namespace bandit {
     settings.after_each(func);
   }
 
-  inline void it_skip(const std::string& desc, std::function<void()> func, detail::settings_t& settings) {
-    settings.it(desc, func, true);
+  inline void it(const std::string& desc, std::function<void()> func,
+      bool hard_skip = false, detail::settings_t& settings = detail::registered_settings()) {
+    settings.it(desc, func, hard_skip);
   }
 
-  inline void it_skip(const std::string& desc, std::function<void()> func) {
-    it_skip(desc, func, detail::registered_settings());
+  inline void it_skip(const std::string& desc, std::function<void()> func,
+      detail::settings_t& settings = detail::registered_settings()) {
+    it(desc, func, true, settings);
   }
 
   inline void xit(const std::string& desc, std::function<void()> func,
       detail::settings_t& settings = detail::registered_settings()) {
-    it_skip(desc, func, settings);
-  }
-
-  inline void it(const std::string& desc, std::function<void()> func, detail::settings_t& settings,
-      bool hard_skip = false) {
-    settings.it(desc, func, hard_skip);
-  }
-
-  inline void it(const std::string& desc, std::function<void()> func, bool hard_skip = false) {
-    it(desc, func, detail::registered_settings(), hard_skip);
+    it(desc, func, true, settings);
   }
 }
 #endif

--- a/bandit/grammar.h
+++ b/bandit/grammar.h
@@ -45,15 +45,9 @@ namespace bandit {
     describe_skip(desc, func, settings, context_stack);
   }
 
-  inline void throw_if_no_context(std::string&& method, const context::stack_t& context_stack) {
-    if (context_stack.empty()) {
-      throw detail::test_run_error("'" + method + "' was called without surrounding 'describe'");
-    }
-  }
-
   inline void before_each(std::function<void()> func,
       context::stack_t& context_stack) {
-    throw_if_no_context("before_each", context_stack);
+    context_stack.throw_if_empty("before_each");
     context_stack.back()->register_before_each(func);
   }
 
@@ -63,7 +57,7 @@ namespace bandit {
 
   inline void after_each(std::function<void()> func,
       context::stack_t& context_stack) {
-    throw_if_no_context("after_each", context_stack);
+    context_stack.throw_if_empty("after_each");
     context_stack.back()->register_after_each(func);
   }
 
@@ -90,7 +84,7 @@ namespace bandit {
     detail::reporter_t& reporter = settings.get_reporter();
     detail::assertion_adapter_t& assertion_adapter = settings.get_adapter();
     detail::run_policy_t& run_policy = settings.get_policy();
-    throw_if_no_context("it", context_stack);
+    context_stack.throw_if_empty("it");
     if (hard_skip || !run_policy.should_run(desc, context_stack)) {
       it_skip(desc, func, settings);
       return;

--- a/bandit/grammar.h
+++ b/bandit/grammar.h
@@ -28,23 +28,13 @@ namespace bandit {
   }
 
   inline void before_each(std::function<void()> func,
-      context::stack_t& context_stack) {
-    context_stack.throw_if_empty("before_each");
-    context_stack.back()->register_before_each(func);
-  }
-
-  inline void before_each(std::function<void()> func) {
-    before_each(func, detail::registered_settings().get_contexts());
+      detail::settings_t& settings = detail::registered_settings()) {
+    settings.before_each(func);
   }
 
   inline void after_each(std::function<void()> func,
-      context::stack_t& context_stack) {
-    context_stack.throw_if_empty("after_each");
-    context_stack.back()->register_after_each(func);
-  }
-
-  inline void after_each(std::function<void()> func) {
-    after_each(func, detail::registered_settings().get_contexts());
+      detail::settings_t& settings = detail::registered_settings()) {
+    settings.after_each(func);
   }
 
   inline void it_skip(const std::string& desc, std::function<void()> func, detail::settings_t& settings) {

--- a/bandit/grammar.h
+++ b/bandit/grammar.h
@@ -1,7 +1,6 @@
 #ifndef BANDIT_GRAMMAR_H
 #define BANDIT_GRAMMAR_H
 
-#include <bandit/adapters.h>
 #include <bandit/settings.h>
 
 namespace bandit {
@@ -156,7 +155,9 @@ namespace bandit {
 
   inline void it(const std::string& desc, std::function<void()> func, bool hard_skip = false) {
     it(desc, func, detail::registered_settings().get_reporter(), context::stack(),
-        detail::registered_adapter(), detail::registered_settings().get_policy(), hard_skip);
+        detail::registered_settings().get_adapter(),
+        detail::registered_settings().get_policy(),
+        hard_skip);
   }
 }
 #endif

--- a/bandit/grammar.h
+++ b/bandit/grammar.h
@@ -4,43 +4,43 @@
 #include <bandit/settings.h>
 
 namespace bandit {
-  inline void describe(const std::string& desc, std::function<void()> func,
+  inline void describe(const std::string& desc, const std::function<void()>& func,
       bool hard_skip = false,
       detail::settings_t& settings = detail::registered_settings()) {
     settings.describe(desc, func, hard_skip);
   }
 
-  inline void describe_skip(const std::string& desc, std::function<void()> func,
+  inline void describe_skip(const std::string& desc, const std::function<void()>& func,
       detail::settings_t& settings = detail::registered_settings()) {
     describe(desc, func, true, settings);
   }
 
-  inline void xdescribe(const std::string& desc, std::function<void()> func,
+  inline void xdescribe(const std::string& desc, const std::function<void()>& func,
       detail::settings_t& settings = detail::registered_settings()) {
     describe(desc, func, true, settings);
   }
 
-  inline void before_each(std::function<void()> func,
+  inline void before_each(const std::function<void()>& func,
       detail::settings_t& settings = detail::registered_settings()) {
     settings.before_each(func);
   }
 
-  inline void after_each(std::function<void()> func,
+  inline void after_each(const std::function<void()>& func,
       detail::settings_t& settings = detail::registered_settings()) {
     settings.after_each(func);
   }
 
-  inline void it(const std::string& desc, std::function<void()> func,
+  inline void it(const std::string& desc, const std::function<void()>& func,
       bool hard_skip = false, detail::settings_t& settings = detail::registered_settings()) {
     settings.it(desc, func, hard_skip);
   }
 
-  inline void it_skip(const std::string& desc, std::function<void()> func,
+  inline void it_skip(const std::string& desc, const std::function<void()>& func,
       detail::settings_t& settings = detail::registered_settings()) {
     it(desc, func, true, settings);
   }
 
-  inline void xit(const std::string& desc, std::function<void()> func,
+  inline void xit(const std::string& desc, const std::function<void()>& func,
       detail::settings_t& settings = detail::registered_settings()) {
     it(desc, func, true, settings);
   }

--- a/bandit/grammar.h
+++ b/bandit/grammar.h
@@ -5,9 +5,9 @@
 
 namespace bandit {
   inline void describe(const std::string& desc, std::function<void()> func,
-      detail::reporter_t& reporter, context::stack_t& context_stack,
+      detail::settings_t& settings, context::stack_t& context_stack,
       bool hard_skip = false) {
-    reporter.context_starting(desc);
+    settings.get_reporter().context_starting(desc);
 
     context_stack.back()->execution_is_starting();
 
@@ -18,32 +18,31 @@ namespace bandit {
     try {
       func();
     } catch (const bandit::detail::test_run_error& error) {
-      reporter.test_run_error(desc, error);
+      settings.get_reporter().test_run_error(desc, error);
     }
 
     context_stack.pop_back();
 
-    reporter.context_ended(desc);
+    settings.get_reporter().context_ended(desc);
   }
 
   inline void describe(const std::string& desc, std::function<void()> func, bool hard_skip = false) {
-    describe(desc, func, detail::registered_settings().get_reporter(), context::stack(), hard_skip);
+    describe(desc, func, detail::registered_settings(), context::stack(), hard_skip);
   }
 
   inline void describe_skip(const std::string& desc, std::function<void()> func,
-      detail::reporter_t& reporter, context::stack_t& context_stack) {
-    describe(desc, func, reporter, context_stack, true);
+      detail::settings_t& settings, context::stack_t& context_stack) {
+    describe(desc, func, settings, context_stack, true);
   }
 
   inline void describe_skip(const std::string& desc, std::function<void()> func) {
-    describe_skip(desc, func, detail::registered_settings().get_reporter(),
-        context::stack());
+    describe_skip(desc, func, detail::registered_settings(), context::stack());
   }
 
   inline void xdescribe(const std::string& desc, std::function<void()> func,
-      detail::reporter_t& reporter = detail::registered_settings().get_reporter(),
+      detail::settings_t& settings = detail::registered_settings(),
       context::stack_t& context_stack = context::stack()) {
-    describe_skip(desc, func, reporter, context_stack);
+    describe_skip(desc, func, settings, context_stack);
   }
 
   inline void throw_if_no_context(std::string&& method, const context::stack_t& context_stack) {
@@ -72,17 +71,17 @@ namespace bandit {
     after_each(func, context::stack());
   }
 
-  inline void it_skip(const std::string& desc, std::function<void()>, detail::reporter_t& reporter) {
-    reporter.it_skip(desc);
+  inline void it_skip(const std::string& desc, std::function<void()>, detail::settings_t& settings) {
+    settings.get_reporter().it_skip(desc);
   }
 
   inline void it_skip(const std::string& desc, std::function<void()> func) {
-    it_skip(desc, func, detail::registered_settings().get_reporter());
+    it_skip(desc, func, detail::registered_settings());
   }
 
   inline void xit(const std::string& desc, std::function<void()> func,
-      detail::reporter_t& reporter = detail::registered_settings().get_reporter()) {
-    it_skip(desc, func, reporter);
+      detail::settings_t& settings = detail::registered_settings()) {
+    it_skip(desc, func, settings);
   }
 
   inline void it(const std::string& desc, std::function<void()> func, detail::settings_t& settings,
@@ -93,7 +92,7 @@ namespace bandit {
     detail::run_policy_t& run_policy = settings.get_policy();
     throw_if_no_context("it", context_stack);
     if (hard_skip || !run_policy.should_run(desc, context_stack)) {
-      it_skip(desc, func, reporter);
+      it_skip(desc, func, settings);
       return;
     }
 

--- a/bandit/grammar.h
+++ b/bandit/grammar.h
@@ -1,48 +1,48 @@
 #ifndef BANDIT_GRAMMAR_H
 #define BANDIT_GRAMMAR_H
 
-#include <bandit/settings.h>
+#include <bandit/controller.h>
 
 namespace bandit {
   inline void describe(const std::string& desc, const std::function<void()>& func,
       bool hard_skip = false,
-      detail::settings_t& settings = detail::registered_settings()) {
-    settings.describe(desc, func, hard_skip);
+      detail::controller_t& controller = detail::registered_controller()) {
+    controller.describe(desc, func, hard_skip);
   }
 
   inline void describe_skip(const std::string& desc, const std::function<void()>& func,
-      detail::settings_t& settings = detail::registered_settings()) {
-    describe(desc, func, true, settings);
+      detail::controller_t& controller = detail::registered_controller()) {
+    describe(desc, func, true, controller);
   }
 
   inline void xdescribe(const std::string& desc, const std::function<void()>& func,
-      detail::settings_t& settings = detail::registered_settings()) {
-    describe(desc, func, true, settings);
+      detail::controller_t& controller = detail::registered_controller()) {
+    describe(desc, func, true, controller);
   }
 
   inline void before_each(const std::function<void()>& func,
-      detail::settings_t& settings = detail::registered_settings()) {
-    settings.before_each(func);
+      detail::controller_t& controller = detail::registered_controller()) {
+    controller.before_each(func);
   }
 
   inline void after_each(const std::function<void()>& func,
-      detail::settings_t& settings = detail::registered_settings()) {
-    settings.after_each(func);
+      detail::controller_t& controller = detail::registered_controller()) {
+    controller.after_each(func);
   }
 
   inline void it(const std::string& desc, const std::function<void()>& func,
-      bool hard_skip = false, detail::settings_t& settings = detail::registered_settings()) {
-    settings.it(desc, func, hard_skip);
+      bool hard_skip = false, detail::controller_t& controller = detail::registered_controller()) {
+    controller.it(desc, func, hard_skip);
   }
 
   inline void it_skip(const std::string& desc, const std::function<void()>& func,
-      detail::settings_t& settings = detail::registered_settings()) {
-    it(desc, func, true, settings);
+      detail::controller_t& controller = detail::registered_controller()) {
+    it(desc, func, true, controller);
   }
 
   inline void xit(const std::string& desc, const std::function<void()>& func,
-      detail::settings_t& settings = detail::registered_settings()) {
-    it(desc, func, true, settings);
+      detail::controller_t& controller = detail::registered_controller()) {
+    it(desc, func, true, controller);
   }
 }
 #endif

--- a/bandit/grammar.h
+++ b/bandit/grammar.h
@@ -2,8 +2,7 @@
 #define BANDIT_GRAMMAR_H
 
 #include <bandit/adapters.h>
-#include <bandit/reporters.h>
-#include <bandit/run_policies.h>
+#include <bandit/settings.h>
 
 namespace bandit {
   inline void describe(const std::string& desc, std::function<void()> func,
@@ -29,7 +28,7 @@ namespace bandit {
   }
 
   inline void describe(const std::string& desc, std::function<void()> func, bool hard_skip = false) {
-    describe(desc, func, detail::registered_reporter(), context::stack(), hard_skip);
+    describe(desc, func, detail::registered_settings().get_reporter(), context::stack(), hard_skip);
   }
 
   inline void describe_skip(const std::string& desc, std::function<void()> func,
@@ -38,12 +37,12 @@ namespace bandit {
   }
 
   inline void describe_skip(const std::string& desc, std::function<void()> func) {
-    describe_skip(desc, func, detail::registered_reporter(),
+    describe_skip(desc, func, detail::registered_settings().get_reporter(),
         context::stack());
   }
 
   inline void xdescribe(const std::string& desc, std::function<void()> func,
-      detail::reporter_t& reporter = detail::registered_reporter(),
+      detail::reporter_t& reporter = detail::registered_settings().get_reporter(),
       context::stack_t& context_stack = context::stack()) {
     describe_skip(desc, func, reporter, context_stack);
   }
@@ -79,11 +78,11 @@ namespace bandit {
   }
 
   inline void it_skip(const std::string& desc, std::function<void()> func) {
-    it_skip(desc, func, detail::registered_reporter());
+    it_skip(desc, func, detail::registered_settings().get_reporter());
   }
 
   inline void xit(const std::string& desc, std::function<void()> func,
-      detail::reporter_t& reporter = detail::registered_reporter()) {
+      detail::reporter_t& reporter = detail::registered_settings().get_reporter()) {
     it_skip(desc, func, reporter);
   }
 
@@ -156,8 +155,8 @@ namespace bandit {
   }
 
   inline void it(const std::string& desc, std::function<void()> func, bool hard_skip = false) {
-    it(desc, func, detail::registered_reporter(), context::stack(),
-        detail::registered_adapter(), detail::registered_run_policy(), hard_skip);
+    it(desc, func, detail::registered_settings().get_reporter(), context::stack(),
+        detail::registered_adapter(), detail::registered_settings().get_policy(), hard_skip);
   }
 }
 #endif

--- a/bandit/options.h
+++ b/bandit/options.h
@@ -226,9 +226,9 @@ namespace bandit {
 
       std::vector<option::Descriptor> usage_;
 
-      std::string reporter_help_;
-      std::string colorizer_help_;
-      std::string formatter_help_;
+      const std::string reporter_help_;
+      const std::string colorizer_help_;
+      const std::string formatter_help_;
 
       std::vector<option::Option> options_;
       run_policy::filter_chain_t filter_chain_;

--- a/bandit/options.h
+++ b/bandit/options.h
@@ -66,7 +66,12 @@ namespace bandit {
         }
       };
 
-      options(int argc, char* argv[], const choice_options& choices = choice_options())
+      static const choice_options& empty_choice_options() {
+        static choice_options choices;
+        return choices;
+      }
+
+      options(int argc, char* argv[], const choice_options& choices = empty_choice_options())
           : choices_(choices),
             usage_{
                 {UNKNOWN, 0, "", "", argument::None,
@@ -158,6 +163,9 @@ namespace bandit {
             chooser_t{"formatter", choices_.formatters, FORMATTER},
             chooser_t{"reporter", choices_.reporters, REPORTER},
         }) {
+          if (chooser.choice.map.empty()) {
+            throw std::runtime_error(std::string("No ") + chooser.name + " set.");
+          }
           if (!apply(settings, chooser.choice, chooser.index)) {
             print_usage(chooser.name, chooser.choice, chooser.index);
             parsed_ok_ = false;
@@ -207,7 +215,7 @@ namespace bandit {
 
       void print_usage(std::string&& what, const option_map& choice, option_index index) const {
         std::cerr << "Unknown " << what << " '" << options_[index].arg << "'." << std::endl;
-        std::cout << "Option argument of '--" << what << "' must be one of: " << choice.comma_separated_list() << std::endl;
+        std::cerr << "Option argument of '--" << what << "' must be one of: " << choice.comma_separated_list() << std::endl;
       }
 
       const option::Descriptor* usage() const {

--- a/bandit/options.h
+++ b/bandit/options.h
@@ -159,10 +159,10 @@ namespace bandit {
           option_index index;
         };
         for (auto chooser : {
-            chooser_t{"colorizer", choices_.colorizers, COLORIZER},
-            chooser_t{"formatter", choices_.formatters, FORMATTER},
-            chooser_t{"reporter", choices_.reporters, REPORTER},
-        }) {
+                 chooser_t{"colorizer", choices_.colorizers, COLORIZER},
+                 chooser_t{"formatter", choices_.formatters, FORMATTER},
+                 chooser_t{"reporter", choices_.reporters, REPORTER},
+             }) {
           if (chooser.choice.map.empty()) {
             throw std::runtime_error(std::string("No ") + chooser.name + " set.");
           }

--- a/bandit/options.h
+++ b/bandit/options.h
@@ -2,137 +2,56 @@
 #define BANDIT_OPTIONS_H
 
 #include <algorithm>
+#include <functional>
+#include <map>
 #include <vector>
 #include <iostream>
 
 #include <bandit/external/optionparser.h>
 #include <bandit/run_policies/filter_chain.h>
+#include <bandit/settings.h>
 
 namespace bandit {
   namespace detail {
+    using settings_func_t = std::function<void(detail::settings_t&)>;
+
+    struct option_map {
+      option_map() : default_it(nullptr) {}
+
+      void add(const std::string& name, settings_func_t func, bool is_default = false) {
+        auto it = map.emplace(std::make_pair(name, func));
+        if (is_default || map.size() == 1) {
+          default_it = it.first;
+        }
+      }
+
+      std::string comma_separated_list() const {
+        std::string csl;
+        auto it = map.begin();
+        if (it != map.end()) {
+          csl += it->first;
+          std::for_each(++it, map.end(), [&](const std::pair<std::string, settings_func_t>& val) {
+            csl += ", " + val.first;
+          });
+        } else {
+          csl = "[no registered entities]";
+        }
+        return csl;
+      }
+
+      using map_type = std::map<std::string, settings_func_t>;
+      map_type map;
+      map_type::iterator default_it;
+    };
+
+    struct choice_options {
+      option_map colorizers;
+      option_map formatters;
+      option_map reporters;
+    };
+
     struct options {
-      template<typename ENUM>
-      struct argstr {
-        ENUM id;
-        std::string str;
-      };
-
-      // a vector of argstr that allows to iterate over the strings only
-      template<typename ENUM>
-      struct argstrs : std::vector<argstr<ENUM>> {
-        using std::vector<argstr<ENUM>>::vector;
-
-        struct str_iterator
-            : public std::iterator<std::input_iterator_tag, std::string, int, const std::string*, std::string> {
-          using base_iterator = typename std::vector<argstr<ENUM>>::const_iterator;
-
-          str_iterator() = delete;
-
-          explicit str_iterator(base_iterator it) : it_(it) {}
-
-          str_iterator& operator++() {
-            ++it_;
-            return *this;
-          }
-
-          str_iterator operator++(int) {
-            str_iterator it(*this);
-            ++(*this);
-            return it;
-          }
-
-          bool operator==(const str_iterator& other) const {
-            return it_ == other.it_;
-          }
-
-          bool operator!=(const str_iterator& other) const {
-            return it_ != other.it_;
-          }
-
-          reference operator*() const {
-            return it_->str;
-          }
-
-          ENUM id() {
-            return it_->id;
-          }
-
-        private:
-          base_iterator it_;
-        };
-
-        str_iterator strbegin() const {
-          return str_iterator(this->begin());
-        };
-
-        str_iterator strend() const {
-          return str_iterator(this->end());
-        };
-      };
-
-      enum class colorizers {
-        OFF,
-        LIGHT,
-        DARK,
-        UNKNOWN
-      };
-
-      enum class formatters {
-        POSIX,
-        VS,
-        UNKNOWN
-      };
-
-      enum class reporters {
-        SINGLELINE,
-        XUNIT,
-        INFO,
-        SPEC,
-        DOTS,
-        CRASH,
-        UNKNOWN
-      };
-
       struct argument : public option::Arg {
-        static const argstrs<reporters> reporter_list() {
-          return {
-              {reporters::CRASH, "crash"},
-              {reporters::DOTS, "dots"},
-              {reporters::SINGLELINE, "singleline"},
-              {reporters::XUNIT, "xunit"},
-              {reporters::INFO, "info"},
-              {reporters::SPEC, "spec"},
-          };
-        }
-
-        static const argstrs<formatters> formatter_list() {
-          return {
-              {formatters::POSIX, "posix"},
-              {formatters::VS, "vs"},
-          };
-        }
-
-        static const argstrs<colorizers> colorizer_list() {
-          return {
-              {colorizers::OFF, "off"},
-              {colorizers::LIGHT, "light"},
-              {colorizers::DARK, "dark"},
-          };
-        }
-
-        template<typename ENUM>
-        static std::string comma_separated_list(argstrs<ENUM> list) {
-          std::string csl;
-          auto first = list.strbegin();
-          if (first != list.strend()) {
-            csl += *first;
-            std::for_each(++first, list.strend(), [&](const std::string& elem) {
-              csl += ", " + elem;
-            });
-          }
-          return csl;
-        }
-
         static std::string name(const option::Option& option) {
           std::string copy(option.name);
           return copy.substr(0, option.namelen);
@@ -148,36 +67,23 @@ namespace bandit {
           return option::ARG_ILLEGAL;
         }
 
-        template<typename ENUM>
-        static option::ArgStatus OneOf(const option::Option& option, bool msg, const argstrs<ENUM>&& list) {
-          auto status = Required(option, msg);
-          if (status == option::ARG_OK && std::find(list.strbegin(), list.strend(), option.arg) == list.strend()) {
-            if (msg) {
-              std::cerr
-                  << "Option argument of '" << name(option) << "' must be one of: "
-                  << comma_separated_list(list)
-                  << std::endl;
-            }
-            status = option::ARG_ILLEGAL;
-          }
-          return status;
-        }
-
+        // XXX: It would be nice to move the code from runner.h here
         static option::ArgStatus Colorizer(const option::Option& option, bool msg) {
-          return OneOf(option, msg, colorizer_list());
+          return Required(option, msg);
         }
 
         static option::ArgStatus Reporter(const option::Option& option, bool msg) {
-          return OneOf(option, msg, reporter_list());
+          return Required(option, msg);
         }
 
         static option::ArgStatus Formatter(const option::Option& option, bool msg) {
-          return OneOf(option, msg, formatter_list());
+          return Required(option, msg);
         }
       };
 
-      options(int argc, char* argv[])
-          : usage_{
+      options(int argc, char* argv[], const choice_options& choices = choice_options())
+          : choices_(choices),
+            usage_{
                 {UNKNOWN, 0, "", "", argument::None,
                     "USAGE: <executable> [options]\n\n"
                     "Options:"},
@@ -198,12 +104,12 @@ namespace bandit {
                     "  --dry-run, "
                     "\tSkip all tests. Use to list available tests"},
             },
-            reporter_help_(append_list("  --reporter=<reporter>, "
-                "\tSelect reporter", argument::reporter_list())),
-            colorizer_help_(append_list("  --colorizer=<colorizer>, "
-                "\tSelect color theme", argument::colorizer_list())),
-            formatter_help_(append_list("  --formatter=<formatter>, "
-                "\tSelect error formatter", argument::formatter_list())) {
+            reporter_help_("  --reporter=<reporter>, "
+                "\tSelect reporter: " + choices_.reporters.comma_separated_list()),
+            colorizer_help_("  --colorizer=<colorizer>, "
+                "\tSelect color theme: " + choices_.colorizers.comma_separated_list()),
+            formatter_help_("  --formatter=<formatter>, "
+                "\tSelect error formatter: " + choices_.formatters.comma_separated_list()) {
         usage_.push_back(option::Descriptor{REPORTER, 0, "", "reporter", argument::Reporter, reporter_help_.c_str()});
         usage_.push_back(option::Descriptor{COLORIZER, 0, "", "colorizer", argument::Colorizer, colorizer_help_.c_str()});
         usage_.push_back(option::Descriptor{FORMATTER, 0, "", "formatter", argument::Formatter, formatter_help_.c_str()});
@@ -256,16 +162,28 @@ namespace bandit {
         return options_[VERSION] != nullptr;
       }
 
-      reporters reporter() const {
-        return get_enumerator_from_string(argument::reporter_list(), options_[REPORTER].arg);
+      bool apply_colorizer(settings_t& settings) const {
+        return apply(settings, choices_.colorizers, COLORIZER);
       }
 
-      colorizers colorizer() const {
-        return get_enumerator_from_string(argument::colorizer_list(), options_[COLORIZER].arg);
+      bool apply_formatter(settings_t& settings) const {
+        return apply(settings, choices_.formatters, FORMATTER);
       }
 
-      formatters formatter() const {
-        return get_enumerator_from_string(argument::formatter_list(), options_[FORMATTER].arg);
+      bool apply_reporter(settings_t& settings) const {
+        return apply(settings, choices_.reporters, REPORTER);
+      }
+
+      void print_usage_colorizer() const {
+        print_usage("colorizer", choices_.colorizers, COLORIZER);
+      }
+
+      void print_usage_formatter() const {
+        print_usage("formatter", choices_.formatters, FORMATTER);
+      }
+
+      void print_usage_reporter() const {
+        print_usage("reporter", choices_.reporters, REPORTER);
       }
 
       const run_policy::filter_chain_t& filter_chain() const {
@@ -281,21 +199,6 @@ namespace bandit {
       }
 
     private:
-      const option::Descriptor* usage() const {
-        return &usage_[0];
-      }
-
-      template<typename ENUM>
-      ENUM get_enumerator_from_string(const argstrs<ENUM>& list, const char* str) const {
-        if (str != nullptr) {
-          auto it = std::find(list.strbegin(), list.strend(), str);
-          if (it != list.strend()) {
-            return it.id();
-          }
-        }
-        return ENUM::UNKNOWN;
-      }
-
       enum option_index {
         UNKNOWN,
         VERSION,
@@ -309,16 +212,35 @@ namespace bandit {
         DRY_RUN,
       };
 
-      template<typename ENUM>
-      static std::string append_list(std::string desc, argstrs<ENUM> list) {
-        return desc + ": " + argument::comma_separated_list(list);
+      bool apply(settings_t& settings, const option_map& choice, enum option_index index) const {
+        option_map::map_type::const_iterator it{choice.default_it};
+        if (options_[index] != nullptr) {
+          it = choice.map.find(std::string(options_[index].arg));
+          if (it == choice.map.end()) {
+            return false;
+          }
+        }
+        it->second(settings);
+        return true;
       }
 
-    private:
+      void print_usage(std::string&& what, const option_map& choice, option_index index) const {
+        std::cerr << "Unknown " << what << " '" << options_[index].arg << "'." << std::endl;
+        std::cout << "Option argument of '--" << what << "' must be one of: " << choice.comma_separated_list() << std::endl;
+      }
+
+      const option::Descriptor* usage() const {
+        return &usage_[0];
+      }
+
+      const choice_options& choices_;
+
       std::vector<option::Descriptor> usage_;
+
       std::string reporter_help_;
       std::string colorizer_help_;
       std::string formatter_help_;
+
       std::vector<option::Option> options_;
       run_policy::filter_chain_t filter_chain_;
       bool parsed_ok_;

--- a/bandit/options.h
+++ b/bandit/options.h
@@ -176,7 +176,39 @@ namespace bandit {
         }
       };
 
-      options(int argc, char* argv[]) {
+      options(int argc, char* argv[])
+          : usage_{
+                {UNKNOWN, 0, "", "", argument::None,
+                    "USAGE: <executable> [options]\n\n"
+                    "Options:"},
+                {VERSION, 0, "", "version", argument::None,
+                    "  --version, \tPrint version of bandit"},
+                {HELP, 0, "", "help", argument::None,
+                    "  --help, \tPrint usage and exit."},
+                {SKIP, 0, "", "skip", argument::Required,
+                    "  --skip=<substring>, "
+                    "\tSkip all 'describe' and 'it' containing substring"},
+                {ONLY, 0, "", "only", argument::Required,
+                    "  --only=<substring>, "
+                    "\tRun only 'describe' and 'it' containing substring"},
+                {BREAK_ON_FAILURE, 0, "", "break-on-failure", argument::None,
+                    "  --break-on-failure, "
+                    "\tStop test run on first failing test"},
+                {DRY_RUN, 0, "", "dry-run", argument::None,
+                    "  --dry-run, "
+                    "\tSkip all tests. Use to list available tests"},
+            },
+            reporter_help_(append_list("  --reporter=<reporter>, "
+                "\tSelect reporter", argument::reporter_list())),
+            colorizer_help_(append_list("  --colorizer=<colorizer>, "
+                "\tSelect color theme", argument::colorizer_list())),
+            formatter_help_(append_list("  --formatter=<formatter>, "
+                "\tSelect error formatter", argument::formatter_list())) {
+        usage_.push_back(option::Descriptor{REPORTER, 0, "", "reporter", argument::Reporter, reporter_help_.c_str()});
+        usage_.push_back(option::Descriptor{COLORIZER, 0, "", "colorizer", argument::Colorizer, colorizer_help_.c_str()});
+        usage_.push_back(option::Descriptor{FORMATTER, 0, "", "formatter", argument::Formatter, formatter_help_.c_str()});
+        usage_.push_back(option::Descriptor{0, 0, 0, 0, 0, 0});
+
         argc -= (argc > 0);
         argv += (argc > 0); // Skip program name (argv[0]) if present
         option::Stats stats(usage(), argc, argv);
@@ -249,6 +281,10 @@ namespace bandit {
       }
 
     private:
+      const option::Descriptor* usage() const {
+        return &usage_[0];
+      }
+
       template<typename ENUM>
       ENUM get_enumerator_from_string(const argstrs<ENUM>& list, const char* str) const {
         if (str != nullptr) {
@@ -278,38 +314,11 @@ namespace bandit {
         return desc + ": " + argument::comma_separated_list(list);
       }
 
-      static const option::Descriptor* usage() {
-        static std::string reporter_help = append_list("  --reporter=<reporter>, "
-            "\tSelect reporter", argument::reporter_list());
-        static std::string colorizer_help = append_list("  --colorizer=<colorizer>, "
-            "\tSelect color theme", argument::colorizer_list());
-        static std::string formatter_help = append_list("  --formatter=<formatter>, "
-            "\tSelect error formatter", argument::formatter_list());
-        static const option::Descriptor usage[] = {
-            {UNKNOWN, 0, "", "", argument::None,
-                "USAGE: <executable> [options]\n\n"
-                "Options:"},
-            {VERSION, 0, "", "version", argument::None,
-                "  --version, \tPrint version of bandit"},
-            {HELP, 0, "", "help", argument::None,
-                "  --help, \tPrint usage and exit."},
-            {REPORTER, 0, "", "reporter", argument::Reporter, reporter_help.c_str()},
-            {COLORIZER, 0, "", "colorizer", argument::Colorizer, colorizer_help.c_str()},
-            {FORMATTER, 0, "", "formatter", argument::Formatter, formatter_help.c_str()},
-            {SKIP, 0, "", "skip", argument::Required,
-                "  --skip=<substring>, \tSkip all 'describe' and 'it' containing substring"},
-            {ONLY, 0, "", "only", argument::Required,
-                "  --only=<substring>, \tRun only 'describe' and 'it' containing substring"},
-            {BREAK_ON_FAILURE, 0, "", "break-on-failure", argument::None,
-                "  --break-on-failure, \tStop test run on first failing test"},
-            {DRY_RUN, 0, "", "dry-run", argument::None,
-                "  --dry-run, \tSkip all tests. Use to list available tests"},
-            {0, 0, 0, 0, 0, 0}};
-
-        return usage;
-      }
-
     private:
+      std::vector<option::Descriptor> usage_;
+      std::string reporter_help_;
+      std::string colorizer_help_;
+      std::string formatter_help_;
       std::vector<option::Option> options_;
       run_policy::filter_chain_t filter_chain_;
       bool parsed_ok_;

--- a/bandit/options.h
+++ b/bandit/options.h
@@ -16,8 +16,6 @@ namespace bandit {
     using settings_func_t = std::function<void(detail::settings_t&)>;
 
     struct option_map {
-      option_map() : default_it(nullptr) {}
-
       void add(const std::string& name, settings_func_t func, bool is_default = false) {
         auto it = map.emplace(std::make_pair(name, func));
         if (is_default || map.size() == 1) {

--- a/bandit/reporters.h
+++ b/bandit/reporters.h
@@ -8,40 +8,4 @@
 #include <bandit/reporters/spec.h>
 #include <bandit/reporters/crash.h>
 
-namespace bandit {
-  namespace detail {
-    struct reporter {
-      // A function is required to initialize a static reporter variable in a header file
-      // and this struct aims at encapsulating this function
-      static void register_reporter(reporter_t* reporter) {
-        if (reporter == nullptr) {
-          throw std::runtime_error("Invalid null reporter passed to "
-                                   "bandit::detail::register_reporter");
-        }
-        get_reporter_address() = reporter;
-      }
-      static reporter_t& registered_reporter() {
-        auto reporter = get_reporter_address();
-        if (reporter == nullptr) {
-          throw std::runtime_error("No reporter set. Please call "
-                                   "bandit::detail::register_reporter with a non-null reporter");
-        }
-        return *reporter;
-      }
-
-    private:
-      static reporter_t*& get_reporter_address() {
-        static reporter_t* reporter_ = nullptr;
-        return reporter_;
-      }
-    };
-
-    inline void register_reporter(reporter_t* reporter) {
-      reporter::register_reporter(reporter);
-    }
-    inline reporter_t& registered_reporter() {
-      return reporter::registered_reporter();
-    }
-  }
-}
 #endif

--- a/bandit/reporters/colored_base.h
+++ b/bandit/reporters/colored_base.h
@@ -2,7 +2,7 @@
 #define BANDIT_REPORTERS_COLORED_BASE_H
 
 #include <ostream>
-#include <bandit/colorizers.h>
+#include <bandit/colorizers/interface.h>
 #include <bandit/reporters/progress_base.h>
 
 namespace bandit {

--- a/bandit/reporters/interface.h
+++ b/bandit/reporters/interface.h
@@ -1,7 +1,6 @@
 #ifndef BANDIT_REPORTERS_INTERFACE_H
 #define BANDIT_REPORTERS_INTERFACE_H
 
-#include <memory>
 #include <bandit/assertion_exception.h>
 #include <bandit/test_run_error.h>
 

--- a/bandit/reporters/interface.h
+++ b/bandit/reporters/interface.h
@@ -29,7 +29,6 @@ namespace bandit {
 
   namespace detail {
     using reporter_t = reporter::interface;
-    using reporter_ptr = std::unique_ptr<reporter_t>;
   }
 }
 #endif

--- a/bandit/reporters/summary.h
+++ b/bandit/reporters/summary.h
@@ -4,7 +4,7 @@
 #include <algorithm>
 #include <list>
 #include <iostream>
-#include <bandit/colorizers.h>
+#include <bandit/colorizers/interface.h>
 
 namespace bandit {
   namespace reporter {

--- a/bandit/run_policies.h
+++ b/bandit/run_policies.h
@@ -5,42 +5,4 @@
 #include <bandit/run_policies/never.h>
 #include <bandit/run_policies/bandit.h>
 
-namespace bandit {
-  namespace detail {
-    struct policy_runner {
-      // A function is required to initialize a static run_policy variable in a header file
-      // and this struct aims at encapsulating this function
-      static void register_run_policy(run_policy_t* policy) {
-        if (policy == nullptr) {
-          throw std::runtime_error("Invalid null policy passed to "
-                                   "bandit::detail::register_run_policy");
-        }
-        get_run_policy_address() = policy;
-      }
-
-      static run_policy_t& registered_run_policy() {
-        auto policy = get_run_policy_address();
-        if (policy == nullptr) {
-          throw std::runtime_error("No policy set. Please call "
-                                   "bandit::detail::register_run_policy with a non-null reporter");
-        }
-        return *policy;
-      }
-
-    private:
-      static run_policy_t*& get_run_policy_address() {
-        static run_policy_t* policy = nullptr;
-        return policy;
-      }
-    };
-
-    inline void register_run_policy(run_policy_t* policy) {
-      policy_runner::register_run_policy(policy);
-    }
-
-    inline run_policy_t& registered_run_policy() {
-      return policy_runner::registered_run_policy();
-    }
-  }
-}
 #endif

--- a/bandit/run_policies/interface.h
+++ b/bandit/run_policies/interface.h
@@ -36,7 +36,6 @@ namespace bandit {
 
   namespace detail {
     using run_policy_t = run_policy::interface;
-    using run_policy_ptr = std::unique_ptr<run_policy_t>;
   }
 }
 #endif

--- a/bandit/run_policies/interface.h
+++ b/bandit/run_policies/interface.h
@@ -1,7 +1,6 @@
 #ifndef BANDIT_RUN_POLICIES_INTERFACE_H
 #define BANDIT_RUN_POLICIES_INTERFACE_H
 
-#include <memory>
 #include <stdexcept>
 #include <bandit/context.h>
 

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -7,7 +7,6 @@
 
 namespace bandit {
   inline int run(const detail::options& opt, const detail::spec_registry& specs,
-      context::stack_t& context_stack,
       detail::settings_t& settings = detail::registered_settings()) {
     if (opt.help() || !opt.parsed_ok()) {
       opt.print_usage();
@@ -23,7 +22,7 @@ namespace bandit {
 
     bool hard_skip = false;
     context::bandit global_context("", hard_skip);
-    context_stack.push_back(&global_context);
+    settings.get_contexts().push_back(&global_context);
 
     for (auto func : specs) {
       func();
@@ -44,7 +43,7 @@ namespace bandit {
 
     detail::settings_t settings(opt);
     detail::register_settings(&settings);
-    return run(opt, detail::specs(), context::stack());
+    return run(opt, detail::specs());
   }
 }
 #endif

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -64,9 +64,6 @@ namespace bandit {
         }
       }
     };
-
-    using reporter_factory_fn = std::function<reporter_ptr(const std::string&, const failure_formatter_t*)>;
-    using register_reporter_fn = std::function<detail::reporter_t*(detail::reporter_t*)>;
   }
 
   inline int run(const detail::options& opt, const detail::spec_registry& specs,

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -42,7 +42,7 @@ namespace bandit {
       return 1;
     }
 
-    detail::settings settings(opt);
+    detail::settings_t settings(opt);
     detail::register_reporter(settings.reporter.get());
     detail::register_run_policy(settings.run_policy.get());
 

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -3,6 +3,7 @@
 
 #include <bandit/options.h>
 #include <bandit/registration/registrar.h>
+#include <bandit/colorizers.h>
 #include <bandit/reporters.h>
 #include <bandit/failure_formatters.h>
 #include <bandit/run_policies.h>

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -85,18 +85,7 @@ namespace bandit {
     }
 
     detail::settings_t settings;
-
-    // XXX: It would be nice to have that moved into bandit::options::arguments
-    if (!opt.apply_colorizer(settings)) {
-      opt.print_usage_colorizer();
-      return 1;
-    }
-    if (!opt.apply_formatter(settings)) {
-      opt.print_usage_formatter();
-      return 1;
-    }
-    if (!opt.apply_reporter(settings)) {
-      opt.print_usage_reporter();
+    if (!opt.update_settings(settings)) {
       return 1;
     }
 

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -19,11 +19,11 @@ namespace bandit {
       settings(const options& opt)
           : colorizer(create_colorizer(opt)),
             formatter(create_formatter(opt)),
-            reporter(create_reporter(opt, *formatter, *colorizer)),
+            reporter(create_reporter(opt)),
             run_policy(new run_policy::bandit(opt.filter_chain(), opt.break_on_failure(), opt.dry_run())) {}
 
     private:
-      static inline colorizer_ptr create_colorizer(const options& opt) {
+      colorizer_ptr create_colorizer(const options& opt) const {
         switch (opt.colorizer()) {
         case options::colorizers::OFF:
           return colorizer_ptr(new colorizer::off());
@@ -35,7 +35,7 @@ namespace bandit {
         }
       }
 
-      static inline failure_formatter_ptr create_formatter(const options& opt) {
+      failure_formatter_ptr create_formatter(const options& opt) const {
         switch (opt.formatter()) {
         case options::formatters::VS:
           return failure_formatter_ptr(new failure_formatter::visual_studio());
@@ -45,22 +45,21 @@ namespace bandit {
         }
       }
 
-      static inline reporter_ptr create_reporter(const options& opt,
-          const failure_formatter_t& formatter, const colorizer_t& colorizer) {
+      reporter_ptr create_reporter(const options& opt) const {
         switch (opt.reporter()) {
         case options::reporters::SINGLELINE:
-          return reporter_ptr(new bandit::reporter::singleline(formatter, colorizer));
+          return reporter_ptr(new bandit::reporter::singleline(*formatter, *colorizer));
         case options::reporters::XUNIT:
-          return reporter_ptr(new bandit::reporter::xunit(formatter));
+          return reporter_ptr(new bandit::reporter::xunit(*formatter));
         case options::reporters::INFO:
-          return reporter_ptr(new bandit::reporter::info(formatter, colorizer));
+          return reporter_ptr(new bandit::reporter::info(*formatter, *colorizer));
         case options::reporters::SPEC:
-          return reporter_ptr(new bandit::reporter::spec(formatter, colorizer));
+          return reporter_ptr(new bandit::reporter::spec(*formatter, *colorizer));
         case options::reporters::CRASH:
-          return reporter_ptr(new bandit::reporter::crash(formatter));
+          return reporter_ptr(new bandit::reporter::crash(*formatter));
         case options::reporters::DOTS:
         default:
-          return reporter_ptr(new bandit::reporter::dots(formatter, colorizer));
+          return reporter_ptr(new bandit::reporter::dots(*formatter, *colorizer));
         }
       }
     };

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -3,7 +3,7 @@
 
 #include <bandit/registration/registrar.h>
 #include <bandit/options.h>
-#include <bandit/settings.h>
+#include <bandit/controller.h>
 #include <bandit/version.h>
 
 #include <bandit/colorizers.h>
@@ -13,7 +13,7 @@
 
 namespace bandit {
   inline int run(const detail::options& opt, const detail::spec_registry& specs,
-      detail::settings_t& settings = detail::registered_settings()) {
+      detail::controller_t& controller = detail::registered_controller()) {
     if (opt.help() || !opt.parsed_ok()) {
       opt.print_usage();
       return !opt.parsed_ok();
@@ -24,60 +24,60 @@ namespace bandit {
       return 0;
     }
 
-    settings.get_reporter().test_run_starting();
+    controller.get_reporter().test_run_starting();
 
     bool hard_skip = false;
     context::bandit global_context("", hard_skip);
-    settings.get_contexts().push_back(&global_context);
+    controller.get_contexts().push_back(&global_context);
 
     for (auto func : specs) {
       func();
     };
 
-    settings.get_reporter().test_run_complete();
+    controller.get_reporter().test_run_complete();
 
-    return settings.get_reporter().did_we_pass() ? 0 : 1;
+    return controller.get_reporter().did_we_pass() ? 0 : 1;
   }
 
   inline void use_default_colorizers(detail::choice_options& choices) {
-    choices.colorizers.add("off", [&](detail::settings_t& settings) {
-      settings.set_colorizer(new colorizer::off());
+    choices.colorizers.add("off", [&](detail::controller_t& controller) {
+      controller.set_colorizer(new colorizer::off());
     });
-    choices.colorizers.add("dark", [&](detail::settings_t& settings) {
-      settings.set_colorizer(new colorizer::dark());
+    choices.colorizers.add("dark", [&](detail::controller_t& controller) {
+      controller.set_colorizer(new colorizer::dark());
     });
-    choices.colorizers.add("light", [&](detail::settings_t& settings) {
-      settings.set_colorizer(new colorizer::light());
+    choices.colorizers.add("light", [&](detail::controller_t& controller) {
+      controller.set_colorizer(new colorizer::light());
     }, true);
   }
 
   inline void use_default_formatters(detail::choice_options& choices) {
-    choices.formatters.add("vs", [&](detail::settings_t& settings) {
-      settings.set_formatter(new failure_formatter::visual_studio());
+    choices.formatters.add("vs", [&](detail::controller_t& controller) {
+      controller.set_formatter(new failure_formatter::visual_studio());
     });
-    choices.formatters.add("posix", [&](detail::settings_t& settings) {
-      settings.set_formatter(new failure_formatter::posix());
+    choices.formatters.add("posix", [&](detail::controller_t& controller) {
+      controller.set_formatter(new failure_formatter::posix());
     }, true);
   }
 
   inline void use_default_reporters(detail::choice_options& choices) {
-    choices.reporters.add("singleline", [&](detail::settings_t& settings) {
-      settings.set_reporter(new bandit::reporter::singleline(settings.get_formatter(), settings.get_colorizer()));
+    choices.reporters.add("singleline", [&](detail::controller_t& controller) {
+      controller.set_reporter(new bandit::reporter::singleline(controller.get_formatter(), controller.get_colorizer()));
     });
-    choices.reporters.add("xunit", [&](detail::settings_t& settings) {
-      settings.set_reporter(new bandit::reporter::xunit(settings.get_formatter()));
+    choices.reporters.add("xunit", [&](detail::controller_t& controller) {
+      controller.set_reporter(new bandit::reporter::xunit(controller.get_formatter()));
     });
-    choices.reporters.add("info", [&](detail::settings_t& settings) {
-      settings.set_reporter(new bandit::reporter::info(settings.get_formatter(), settings.get_colorizer()));
+    choices.reporters.add("info", [&](detail::controller_t& controller) {
+      controller.set_reporter(new bandit::reporter::info(controller.get_formatter(), controller.get_colorizer()));
     });
-    choices.reporters.add("spec", [&](detail::settings_t& settings) {
-      settings.set_reporter(new bandit::reporter::spec(settings.get_formatter(), settings.get_colorizer()));
+    choices.reporters.add("spec", [&](detail::controller_t& controller) {
+      controller.set_reporter(new bandit::reporter::spec(controller.get_formatter(), controller.get_colorizer()));
     });
-    choices.reporters.add("crash", [&](detail::settings_t& settings) {
-      settings.set_reporter(new bandit::reporter::crash(settings.get_formatter()));
+    choices.reporters.add("crash", [&](detail::controller_t& controller) {
+      controller.set_reporter(new bandit::reporter::crash(controller.get_formatter()));
     });
-    choices.reporters.add("dots", [&](detail::settings_t& settings) {
-      settings.set_reporter(new bandit::reporter::dots(settings.get_formatter(), settings.get_colorizer()));
+    choices.reporters.add("dots", [&](detail::controller_t& controller) {
+      controller.set_reporter(new bandit::reporter::dots(controller.get_formatter(), controller.get_colorizer()));
     }, true);
   }
 
@@ -96,14 +96,14 @@ namespace bandit {
       return 1;
     }
 
-    detail::settings_t settings;
-    if (!opt.update_settings(settings)) {
+    detail::controller_t controller;
+    if (!opt.update_controller_settings(controller)) {
       return 1;
     }
 
-    settings.set_policy(new run_policy::bandit(opt.filter_chain(), opt.break_on_failure(), opt.dry_run()));
+    controller.set_policy(new run_policy::bandit(opt.filter_chain(), opt.break_on_failure(), opt.dry_run()));
 
-    detail::register_settings(&settings);
+    detail::register_controller(&controller);
     return run(opt, detail::specs());
   }
 

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -66,7 +66,8 @@ namespace bandit {
   }
 
   inline int run(const detail::options& opt, const detail::spec_registry& specs,
-      context::stack_t& context_stack, detail::reporter_t& reporter) {
+      context::stack_t& context_stack,
+      detail::reporter_t& reporter = detail::registered_reporter()) {
     if (opt.help() || !opt.parsed_ok()) {
       opt.print_usage();
       return !opt.parsed_ok();
@@ -104,7 +105,7 @@ namespace bandit {
     detail::register_reporter(settings.reporter.get());
     detail::register_run_policy(settings.run_policy.get());
 
-    return run(opt, detail::specs(), context::stack(), *settings.reporter);
+    return run(opt, detail::specs(), context::stack());
   }
 }
 #endif

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -39,9 +39,7 @@ namespace bandit {
     return settings.get_reporter().did_we_pass() ? 0 : 1;
   }
 
-  inline int run(int argc, char* argv[], bool allow_further = true) {
-    detail::choice_options choices;
-
+  inline void use_default_colorizers(detail::choice_options& choices) {
     choices.colorizers.add("off", [&](detail::settings_t& settings) {
       settings.set_colorizer(new colorizer::off());
     });
@@ -51,12 +49,18 @@ namespace bandit {
     choices.colorizers.add("light", [&](detail::settings_t& settings) {
       settings.set_colorizer(new colorizer::light());
     }, true);
+  }
+
+  inline void use_default_formatters(detail::choice_options& choices) {
     choices.formatters.add("vs", [&](detail::settings_t& settings) {
       settings.set_formatter(new failure_formatter::visual_studio());
     });
     choices.formatters.add("posix", [&](detail::settings_t& settings) {
       settings.set_formatter(new failure_formatter::posix());
     }, true);
+  }
+
+  inline void use_default_reporters(detail::choice_options& choices) {
     choices.reporters.add("singleline", [&](detail::settings_t& settings) {
       settings.set_reporter(new bandit::reporter::singleline(settings.get_formatter(), settings.get_colorizer()));
     });
@@ -75,7 +79,15 @@ namespace bandit {
     choices.reporters.add("dots", [&](detail::settings_t& settings) {
       settings.set_reporter(new bandit::reporter::dots(settings.get_formatter(), settings.get_colorizer()));
     }, true);
+  }
 
+  inline void use_defaults(detail::choice_options& choices) {
+    use_default_colorizers(choices);
+    use_default_formatters(choices);
+    use_default_reporters(choices);
+  }
+
+  inline int run(int argc, char* argv[], const detail::choice_options& choices, bool allow_further = true) {
     detail::options opt(argc, argv, choices);
 
     if (!allow_further &&
@@ -93,6 +105,14 @@ namespace bandit {
 
     detail::register_settings(&settings);
     return run(opt, detail::specs());
+  }
+
+  inline int run(int argc, char* argv[], bool allow_further = true) {
+    detail::choice_options choices;
+
+    use_defaults(choices);
+
+    return run(argc, argv, choices, allow_further);
   }
 }
 #endif

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -8,7 +8,7 @@
 namespace bandit {
   inline int run(const detail::options& opt, const detail::spec_registry& specs,
       context::stack_t& context_stack,
-      detail::reporter_t& reporter = detail::registered_reporter()) {
+      detail::reporter_t& reporter = detail::registered_settings().get_reporter()) {
     if (opt.help() || !opt.parsed_ok()) {
       opt.print_usage();
       return !opt.parsed_ok();
@@ -43,9 +43,7 @@ namespace bandit {
     }
 
     detail::settings_t settings(opt);
-    detail::register_reporter(settings.reporter.get());
-    detail::register_run_policy(settings.run_policy.get());
-
+    detail::register_settings(&settings);
     return run(opt, detail::specs(), context::stack());
   }
 }

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -2,8 +2,14 @@
 #define BANDIT_RUNNER_H
 
 #include <bandit/registration/registrar.h>
+#include <bandit/options.h>
 #include <bandit/settings.h>
 #include <bandit/version.h>
+
+#include <bandit/colorizers.h>
+#include <bandit/failure_formatters.h>
+#include <bandit/reporters.h>
+#include <bandit/run_policies.h>
 
 namespace bandit {
   inline int run(const detail::options& opt, const detail::spec_registry& specs,
@@ -41,7 +47,51 @@ namespace bandit {
       return 1;
     }
 
-    detail::settings_t settings(opt);
+    detail::settings_t settings;
+    switch (opt.colorizer()) {
+    case detail::options::colorizers::OFF:
+      settings.set_colorizer(new colorizer::off());
+      break;
+    case detail::options::colorizers::DARK:
+      settings.set_colorizer(new colorizer::dark());
+      break;
+    case detail::options::colorizers::LIGHT:
+    default:
+      settings.set_colorizer(new colorizer::light());
+    }
+
+    switch (opt.formatter()) {
+    case detail::options::formatters::VS:
+      settings.set_formatter(new failure_formatter::visual_studio());
+      break;
+    case detail::options::formatters::POSIX:
+    default:
+      settings.set_formatter(new failure_formatter::posix());
+    }
+
+    switch (opt.reporter()) {
+    case detail::options::reporters::SINGLELINE:
+      settings.set_reporter(new bandit::reporter::singleline(settings.get_formatter(), settings.get_colorizer()));
+      break;
+    case detail::options::reporters::XUNIT:
+      settings.set_reporter(new bandit::reporter::xunit(settings.get_formatter()));
+      break;
+    case detail::options::reporters::INFO:
+      settings.set_reporter(new bandit::reporter::info(settings.get_formatter(), settings.get_colorizer()));
+      break;
+    case detail::options::reporters::SPEC:
+      settings.set_reporter(new bandit::reporter::spec(settings.get_formatter(), settings.get_colorizer()));
+      break;
+    case detail::options::reporters::CRASH:
+      settings.set_reporter(new bandit::reporter::crash(settings.get_formatter()));
+      break;
+    case detail::options::reporters::DOTS:
+    default:
+      settings.set_reporter(new bandit::reporter::dots(settings.get_formatter(), settings.get_colorizer()));
+    }
+
+    settings.set_policy(new run_policy::bandit(opt.filter_chain(), opt.break_on_failure(), opt.dry_run()));
+
     detail::register_settings(&settings);
     return run(opt, detail::specs());
   }

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -8,7 +8,7 @@
 namespace bandit {
   inline int run(const detail::options& opt, const detail::spec_registry& specs,
       context::stack_t& context_stack,
-      detail::reporter_t& reporter = detail::registered_settings().get_reporter()) {
+      detail::settings_t& settings = detail::registered_settings()) {
     if (opt.help() || !opt.parsed_ok()) {
       opt.print_usage();
       return !opt.parsed_ok();
@@ -19,7 +19,7 @@ namespace bandit {
       return 0;
     }
 
-    reporter.test_run_starting();
+    settings.get_reporter().test_run_starting();
 
     bool hard_skip = false;
     context::bandit global_context("", hard_skip);
@@ -29,9 +29,9 @@ namespace bandit {
       func();
     };
 
-    reporter.test_run_complete();
+    settings.get_reporter().test_run_complete();
 
-    return reporter.did_we_pass() ? 0 : 1;
+    return settings.get_reporter().did_we_pass() ? 0 : 1;
   }
 
   inline int run(int argc, char* argv[], bool allow_further = true) {

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -1,71 +1,11 @@
 #ifndef BANDIT_RUNNER_H
 #define BANDIT_RUNNER_H
 
-#include <bandit/options.h>
 #include <bandit/registration/registrar.h>
-#include <bandit/colorizers.h>
-#include <bandit/reporters.h>
-#include <bandit/failure_formatters.h>
-#include <bandit/run_policies.h>
+#include <bandit/settings.h>
 #include <bandit/version.h>
 
 namespace bandit {
-  namespace detail {
-    struct settings {
-      colorizer_ptr colorizer;
-      failure_formatter_ptr formatter;
-      reporter_ptr reporter;
-      run_policy_ptr run_policy;
-
-      settings(const options& opt)
-          : colorizer(create_colorizer(opt)),
-            formatter(create_formatter(opt)),
-            reporter(create_reporter(opt)),
-            run_policy(new run_policy::bandit(opt.filter_chain(), opt.break_on_failure(), opt.dry_run())) {}
-
-    private:
-      colorizer_ptr create_colorizer(const options& opt) const {
-        switch (opt.colorizer()) {
-        case options::colorizers::OFF:
-          return colorizer_ptr(new colorizer::off());
-        case options::colorizers::DARK:
-          return colorizer_ptr(new colorizer::dark());
-        case options::colorizers::LIGHT:
-        default:
-          return colorizer_ptr(new colorizer::light());
-        }
-      }
-
-      failure_formatter_ptr create_formatter(const options& opt) const {
-        switch (opt.formatter()) {
-        case options::formatters::VS:
-          return failure_formatter_ptr(new failure_formatter::visual_studio());
-        case options::formatters::POSIX:
-        default:
-          return failure_formatter_ptr(new failure_formatter::posix());
-        }
-      }
-
-      reporter_ptr create_reporter(const options& opt) const {
-        switch (opt.reporter()) {
-        case options::reporters::SINGLELINE:
-          return reporter_ptr(new bandit::reporter::singleline(*formatter, *colorizer));
-        case options::reporters::XUNIT:
-          return reporter_ptr(new bandit::reporter::xunit(*formatter));
-        case options::reporters::INFO:
-          return reporter_ptr(new bandit::reporter::info(*formatter, *colorizer));
-        case options::reporters::SPEC:
-          return reporter_ptr(new bandit::reporter::spec(*formatter, *colorizer));
-        case options::reporters::CRASH:
-          return reporter_ptr(new bandit::reporter::crash(*formatter));
-        case options::reporters::DOTS:
-        default:
-          return reporter_ptr(new bandit::reporter::dots(*formatter, *colorizer));
-        }
-      }
-    };
-  }
-
   inline int run(const detail::options& opt, const detail::spec_registry& specs,
       context::stack_t& context_stack,
       detail::reporter_t& reporter = detail::registered_reporter()) {

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -10,53 +10,63 @@
 
 namespace bandit {
   namespace detail {
-    inline run_policy_ptr create_run_policy(const options& opt) {
-      return run_policy_ptr(new run_policy::bandit(opt.filter_chain(), opt.break_on_failure(), opt.dry_run()));
-    }
+    struct settings {
+      colorizer_ptr colorizer;
+      failure_formatter_ptr formatter;
+      reporter_ptr reporter;
+      run_policy_ptr run_policy;
 
-    inline reporter_ptr create_reporter(const options& opt,
-        const failure_formatter_t& formatter, const colorizer_t& colorizer) {
-      switch (opt.reporter()) {
-      case options::reporters::SINGLELINE:
-        return reporter_ptr(new bandit::reporter::singleline(formatter, colorizer));
-      case options::reporters::XUNIT:
-        return reporter_ptr(new bandit::reporter::xunit(formatter));
-      case options::reporters::INFO:
-        return reporter_ptr(new bandit::reporter::info(formatter, colorizer));
-      case options::reporters::SPEC:
-        return reporter_ptr(new bandit::reporter::spec(formatter, colorizer));
-      case options::reporters::CRASH:
-        return reporter_ptr(new bandit::reporter::crash(formatter));
-      case options::reporters::DOTS:
-      default:
-        return reporter_ptr(new bandit::reporter::dots(formatter, colorizer));
+      settings(const options& opt)
+          : colorizer(create_colorizer(opt)),
+            formatter(create_formatter(opt)),
+            reporter(create_reporter(opt, *formatter, *colorizer)),
+            run_policy(new run_policy::bandit(opt.filter_chain(), opt.break_on_failure(), opt.dry_run())) {}
+
+    private:
+      static inline colorizer_ptr create_colorizer(const options& opt) {
+        switch (opt.colorizer()) {
+        case options::colorizers::OFF:
+          return colorizer_ptr(new colorizer::off());
+        case options::colorizers::DARK:
+          return colorizer_ptr(new colorizer::dark());
+        case options::colorizers::LIGHT:
+        default:
+          return colorizer_ptr(new colorizer::light());
+        }
       }
-    }
+
+      static inline failure_formatter_ptr create_formatter(const options& opt) {
+        switch (opt.formatter()) {
+        case options::formatters::VS:
+          return failure_formatter_ptr(new failure_formatter::visual_studio());
+        case options::formatters::POSIX:
+        default:
+          return failure_formatter_ptr(new failure_formatter::posix());
+        }
+      }
+
+      static inline reporter_ptr create_reporter(const options& opt,
+          const failure_formatter_t& formatter, const colorizer_t& colorizer) {
+        switch (opt.reporter()) {
+        case options::reporters::SINGLELINE:
+          return reporter_ptr(new bandit::reporter::singleline(formatter, colorizer));
+        case options::reporters::XUNIT:
+          return reporter_ptr(new bandit::reporter::xunit(formatter));
+        case options::reporters::INFO:
+          return reporter_ptr(new bandit::reporter::info(formatter, colorizer));
+        case options::reporters::SPEC:
+          return reporter_ptr(new bandit::reporter::spec(formatter, colorizer));
+        case options::reporters::CRASH:
+          return reporter_ptr(new bandit::reporter::crash(formatter));
+        case options::reporters::DOTS:
+        default:
+          return reporter_ptr(new bandit::reporter::dots(formatter, colorizer));
+        }
+      }
+    };
 
     using reporter_factory_fn = std::function<reporter_ptr(const std::string&, const failure_formatter_t*)>;
     using register_reporter_fn = std::function<detail::reporter_t*(detail::reporter_t*)>;
-
-    inline failure_formatter_ptr create_formatter(const options& opt) {
-      switch (opt.formatter()) {
-      case options::formatters::VS:
-        return failure_formatter_ptr(new failure_formatter::visual_studio());
-      case options::formatters::POSIX:
-      default:
-        return failure_formatter_ptr(new failure_formatter::posix());
-      }
-    }
-
-    inline colorizer_ptr create_colorizer(const options& opt) {
-      switch (opt.colorizer()) {
-      case options::colorizers::OFF:
-        return colorizer_ptr(new colorizer::off());
-      case options::colorizers::DARK:
-        return colorizer_ptr(new colorizer::dark());
-      case options::colorizers::LIGHT:
-      default:
-        return colorizer_ptr(new colorizer::light());
-      }
-    }
   }
 
   inline int run(const detail::options& opt, const detail::spec_registry& specs,
@@ -94,15 +104,11 @@ namespace bandit {
       return 1;
     }
 
-    detail::failure_formatter_ptr formatter(create_formatter(opt));
-    detail::colorizer_ptr colorizer(create_colorizer(opt));
-    detail::reporter_ptr reporter(create_reporter(opt, *formatter, *colorizer));
-    detail::run_policy_ptr run_policy(create_run_policy(opt));
+    detail::settings settings(opt);
+    detail::register_reporter(settings.reporter.get());
+    detail::register_run_policy(settings.run_policy.get());
 
-    detail::register_reporter(reporter.get());
-    detail::register_run_policy(run_policy.get());
-
-    return run(opt, detail::specs(), context::stack(), *reporter);
+    return run(opt, detail::specs(), context::stack(), *settings.reporter);
   }
 }
 #endif

--- a/bandit/settings.h
+++ b/bandit/settings.h
@@ -1,0 +1,67 @@
+#ifndef BANDIT_SETTINGS_H
+#define BANDIT_SETTINGS_H
+
+#include <bandit/colorizers.h>
+#include <bandit/failure_formatters.h>
+#include <bandit/options.h>
+#include <bandit/reporters.h>
+#include <bandit/run_policies.h>
+
+namespace bandit {
+  namespace detail {
+    struct settings {
+      colorizer_ptr colorizer;
+      failure_formatter_ptr formatter;
+      reporter_ptr reporter;
+      run_policy_ptr run_policy;
+
+      settings(const options& opt)
+          : colorizer(create_colorizer(opt)),
+            formatter(create_formatter(opt)),
+            reporter(create_reporter(opt)),
+            run_policy(new run_policy::bandit(opt.filter_chain(), opt.break_on_failure(), opt.dry_run())) {}
+
+    private:
+      colorizer_ptr create_colorizer(const options& opt) const {
+        switch (opt.colorizer()) {
+        case options::colorizers::OFF:
+          return colorizer_ptr(new colorizer::off());
+        case options::colorizers::DARK:
+          return colorizer_ptr(new colorizer::dark());
+        case options::colorizers::LIGHT:
+        default:
+          return colorizer_ptr(new colorizer::light());
+        }
+      }
+
+      failure_formatter_ptr create_formatter(const options& opt) const {
+        switch (opt.formatter()) {
+        case options::formatters::VS:
+          return failure_formatter_ptr(new failure_formatter::visual_studio());
+        case options::formatters::POSIX:
+        default:
+          return failure_formatter_ptr(new failure_formatter::posix());
+        }
+      }
+
+      reporter_ptr create_reporter(const options& opt) const {
+        switch (opt.reporter()) {
+        case options::reporters::SINGLELINE:
+          return reporter_ptr(new bandit::reporter::singleline(*formatter, *colorizer));
+        case options::reporters::XUNIT:
+          return reporter_ptr(new bandit::reporter::xunit(*formatter));
+        case options::reporters::INFO:
+          return reporter_ptr(new bandit::reporter::info(*formatter, *colorizer));
+        case options::reporters::SPEC:
+          return reporter_ptr(new bandit::reporter::spec(*formatter, *colorizer));
+        case options::reporters::CRASH:
+          return reporter_ptr(new bandit::reporter::crash(*formatter));
+        case options::reporters::DOTS:
+        default:
+          return reporter_ptr(new bandit::reporter::dots(*formatter, *colorizer));
+        }
+      }
+    };
+  }
+}
+#endif

--- a/bandit/settings.h
+++ b/bandit/settings.h
@@ -9,13 +9,13 @@
 
 namespace bandit {
   namespace detail {
-    struct settings {
+    struct settings_t {
       colorizer_ptr colorizer;
       failure_formatter_ptr formatter;
       reporter_ptr reporter;
       run_policy_ptr run_policy;
 
-      settings(const options& opt)
+      settings_t(const options& opt)
           : colorizer(create_colorizer(opt)),
             formatter(create_formatter(opt)),
             reporter(create_reporter(opt)),

--- a/bandit/settings.h
+++ b/bandit/settings.h
@@ -164,52 +164,52 @@ namespace bandit {
         }
       }
 
-      colorizer_ptr create_colorizer(const options& opt) const {
+      colorizer_t* create_colorizer(const options& opt) const {
         switch (opt.colorizer()) {
         case options::colorizers::OFF:
-          return colorizer_ptr(new colorizer::off());
+          return new colorizer::off();
         case options::colorizers::DARK:
-          return colorizer_ptr(new colorizer::dark());
+          return new colorizer::dark();
         case options::colorizers::LIGHT:
         default:
-          return colorizer_ptr(new colorizer::light());
+          return new colorizer::light();
         }
       }
 
-      failure_formatter_ptr create_formatter(const options& opt) const {
+      failure_formatter_t* create_formatter(const options& opt) const {
         switch (opt.formatter()) {
         case options::formatters::VS:
-          return failure_formatter_ptr(new failure_formatter::visual_studio());
+          return new failure_formatter::visual_studio();
         case options::formatters::POSIX:
         default:
-          return failure_formatter_ptr(new failure_formatter::posix());
+          return new failure_formatter::posix();
         }
       }
 
-      reporter_ptr create_reporter(const options& opt) const {
+      reporter_t* create_reporter(const options& opt) const {
         switch (opt.reporter()) {
         case options::reporters::SINGLELINE:
-          return reporter_ptr(new bandit::reporter::singleline(*formatter, *colorizer));
+          return new bandit::reporter::singleline(*formatter, *colorizer);
         case options::reporters::XUNIT:
-          return reporter_ptr(new bandit::reporter::xunit(*formatter));
+          return new bandit::reporter::xunit(*formatter);
         case options::reporters::INFO:
-          return reporter_ptr(new bandit::reporter::info(*formatter, *colorizer));
+          return new bandit::reporter::info(*formatter, *colorizer);
         case options::reporters::SPEC:
-          return reporter_ptr(new bandit::reporter::spec(*formatter, *colorizer));
+          return new bandit::reporter::spec(*formatter, *colorizer);
         case options::reporters::CRASH:
-          return reporter_ptr(new bandit::reporter::crash(*formatter));
+          return new bandit::reporter::crash(*formatter);
         case options::reporters::DOTS:
         default:
-          return reporter_ptr(new bandit::reporter::dots(*formatter, *colorizer));
+          return new bandit::reporter::dots(*formatter, *colorizer);
         }
       }
 
       context::stack_t context_stack;
-      assertion_adapter_ptr adapter;
-      colorizer_ptr colorizer;
-      failure_formatter_ptr formatter;
-      reporter_ptr reporter;
-      run_policy_ptr run_policy;
+      std::unique_ptr<assertion_adapter_t> adapter;
+      std::unique_ptr<colorizer_t> colorizer;
+      std::unique_ptr<failure_formatter_t> formatter;
+      std::unique_ptr<reporter_t> reporter;
+      std::unique_ptr<run_policy_t> run_policy;
     };
 
     inline void register_settings(settings_t* settings) {

--- a/bandit/settings.h
+++ b/bandit/settings.h
@@ -20,6 +20,10 @@ namespace bandit {
 
       settings_t() : settings_t(options(0, nullptr)) {}
 
+      context::stack_t& get_contexts() {
+        return context_stack;
+      }
+
       assertion_adapter_t& get_adapter() {
         return *adapter;
       }
@@ -109,6 +113,7 @@ namespace bandit {
         }
       }
 
+      context::stack_t context_stack;
       assertion_adapter_ptr adapter;
       colorizer_ptr colorizer;
       failure_formatter_ptr formatter;

--- a/bandit/settings.h
+++ b/bandit/settings.h
@@ -21,7 +21,39 @@ namespace bandit {
             reporter(create_reporter(opt)),
             run_policy(new run_policy::bandit(opt.filter_chain(), opt.break_on_failure(), opt.dry_run())) {}
 
+      reporter_t& get_reporter() {
+        return *reporter;
+      }
+
+      run_policy_t& get_policy() {
+        return *run_policy;
+      }
+
+      // A function is required to initialize a static settings variable in a header file
+      // and this struct aims at encapsulating this function
+      static void register_settings(settings_t* settings) {
+        if (settings == nullptr) {
+          throw std::runtime_error("Invalid null settings passed to "
+                                   "bandit::detail::register_settings");
+        }
+        get_settings_address() = settings;
+      }
+
+      static settings_t& registered_settings() {
+        auto settings = get_settings_address();
+        if (settings == nullptr) {
+          throw std::runtime_error("No settings set. Please call "
+                                   "bandit::detail::register_settings with a non-null settings");
+        }
+        return *settings;
+      }
+
     private:
+      static settings_t*& get_settings_address() {
+        static settings_t* settings_ = nullptr;
+        return settings_;
+      }
+
       colorizer_ptr create_colorizer(const options& opt) const {
         switch (opt.colorizer()) {
         case options::colorizers::OFF:
@@ -62,6 +94,14 @@ namespace bandit {
         }
       }
     };
+
+    inline void register_settings(settings_t* settings) {
+      settings_t::register_settings(settings);
+    }
+
+    inline settings_t& registered_settings() {
+      return settings_t::registered_settings();
+    }
   }
 }
 #endif

--- a/bandit/settings.h
+++ b/bandit/settings.h
@@ -48,6 +48,89 @@ namespace bandit {
         run_policy.reset(run_policy_);
       }
 
+      void describe(const std::string& desc, std::function<void()> func, bool hard_skip) {
+        reporter->context_starting(desc);
+
+        context_stack.back()->execution_is_starting();
+
+        context::bandit ctxt(desc, hard_skip);
+
+        context_stack.push_back(&ctxt);
+
+        try {
+          func();
+        } catch (const bandit::detail::test_run_error& error) {
+          reporter->test_run_error(desc, error);
+        }
+
+        context_stack.pop_back();
+
+        reporter->context_ended(desc);
+      }
+
+      void it(const std::string& desc, std::function<void()> func, bool hard_skip) {
+        context_stack.throw_if_empty("it");
+        if (hard_skip || !run_policy->should_run(desc, context_stack)) {
+          reporter->it_skip(desc);
+          return;
+        }
+
+        reporter->it_starting(desc);
+        context_stack.back()->execution_is_starting();
+
+        auto try_with_adapter = [&](bool allow_fail, std::function<void()> do_it) {
+          if (allow_fail) {
+            try {
+              adapter->adapt_exceptions([&] { do_it(); });
+            } catch (const bandit::detail::assertion_exception& ex) {
+              reporter->it_failed(desc, ex);
+              run_policy->encountered_failure();
+            } catch (const std::exception& ex) {
+              std::string err = std::string("exception: ") + ex.what();
+              reporter->it_failed(desc, bandit::detail::assertion_exception(err));
+              run_policy->encountered_failure();
+            } catch (...) {
+              reporter->it_unknown_error(desc);
+              run_policy->encountered_failure();
+            }
+          } else {
+            try {
+              do_it();
+            } catch (...) {
+              /* ignore */
+            }
+          }
+        };
+
+        bool success = false;
+        context::interface* last_successful_before_each_context = nullptr;
+        try_with_adapter(true, [&] {
+          for (auto context : context_stack) {
+            context->run_before_eaches();
+            last_successful_before_each_context = context;
+          }
+
+          func();
+          success = true;
+        });
+
+        try_with_adapter(success, [&] {
+          bool do_run_after_each = false;
+          std::for_each(context_stack.rbegin(), context_stack.rend(), [&](context::interface* context) {
+            if (context == last_successful_before_each_context) {
+              do_run_after_each = true;
+            }
+            if (do_run_after_each) {
+              context->run_after_eaches();
+            }
+          });
+
+          if (success) {
+            reporter->it_succeeded(desc);
+          }
+        });
+      }
+
       // A function is required to initialize a static settings variable in a header file
       // and this struct aims at encapsulating this function
       static void register_settings(settings_t* settings) {

--- a/bandit/settings.h
+++ b/bandit/settings.h
@@ -11,12 +11,6 @@
 namespace bandit {
   namespace detail {
     struct settings_t {
-      assertion_adapter_ptr adapter;
-      colorizer_ptr colorizer;
-      failure_formatter_ptr formatter;
-      reporter_ptr reporter;
-      run_policy_ptr run_policy;
-
       settings_t(const options& opt)
           : adapter(new adapter::snowhouse),
             colorizer(create_colorizer(opt)),
@@ -24,16 +18,30 @@ namespace bandit {
             reporter(create_reporter(opt)),
             run_policy(new run_policy::bandit(opt.filter_chain(), opt.break_on_failure(), opt.dry_run())) {}
 
+      settings_t() : settings_t(options(0, nullptr)) {}
+
       assertion_adapter_t& get_adapter() {
         return *adapter;
+      }
+
+      void set_adapter(assertion_adapter_t* adapter_) {
+        adapter.reset(adapter_);
       }
 
       reporter_t& get_reporter() {
         return *reporter;
       }
 
+      void set_reporter(reporter_t* reporter_) {
+        reporter.reset(reporter_);
+      }
+
       run_policy_t& get_policy() {
         return *run_policy;
+      }
+
+      void set_policy(run_policy_t* run_policy_) {
+        run_policy.reset(run_policy_);
       }
 
       // A function is required to initialize a static settings variable in a header file
@@ -100,6 +108,12 @@ namespace bandit {
           return reporter_ptr(new bandit::reporter::dots(*formatter, *colorizer));
         }
       }
+
+      assertion_adapter_ptr adapter;
+      colorizer_ptr colorizer;
+      failure_formatter_ptr formatter;
+      reporter_ptr reporter;
+      run_policy_ptr run_policy;
     };
 
     inline void register_settings(settings_t* settings) {

--- a/bandit/settings.h
+++ b/bandit/settings.h
@@ -54,7 +54,6 @@ namespace bandit {
         context_stack.back()->execution_is_starting();
 
         context::bandit ctxt(desc, hard_skip);
-
         context_stack.push_back(&ctxt);
 
         try {
@@ -72,63 +71,38 @@ namespace bandit {
         context_stack.throw_if_empty("it");
         if (hard_skip || !run_policy->should_run(desc, context_stack)) {
           reporter->it_skip(desc);
-          return;
-        }
+        } else {
+          reporter->it_starting(desc);
+          context_stack.back()->execution_is_starting();
 
-        reporter->it_starting(desc);
-        context_stack.back()->execution_is_starting();
-
-        auto try_with_adapter = [&](bool allow_fail, std::function<void()> do_it) {
-          if (allow_fail) {
-            try {
-              adapter->adapt_exceptions([&] { do_it(); });
-            } catch (const bandit::detail::assertion_exception& ex) {
-              reporter->it_failed(desc, ex);
-              run_policy->encountered_failure();
-            } catch (const std::exception& ex) {
-              std::string err = std::string("exception: ") + ex.what();
-              reporter->it_failed(desc, bandit::detail::assertion_exception(err));
-              run_policy->encountered_failure();
-            } catch (...) {
-              reporter->it_unknown_error(desc);
-              run_policy->encountered_failure();
+          bool success = false;
+          context::interface* last_successful_before_each_context = nullptr;
+          try_with_adapter(desc, true, [&] {
+            for (auto context : context_stack) {
+              context->run_before_eaches();
+              last_successful_before_each_context = context;
             }
-          } else {
-            try {
-              do_it();
-            } catch (...) {
-              /* ignore */
-            }
-          }
-        };
 
-        bool success = false;
-        context::interface* last_successful_before_each_context = nullptr;
-        try_with_adapter(true, [&] {
-          for (auto context : context_stack) {
-            context->run_before_eaches();
-            last_successful_before_each_context = context;
-          }
-
-          func();
-          success = true;
-        });
-
-        try_with_adapter(success, [&] {
-          bool do_run_after_each = false;
-          std::for_each(context_stack.rbegin(), context_stack.rend(), [&](context::interface* context) {
-            if (context == last_successful_before_each_context) {
-              do_run_after_each = true;
-            }
-            if (do_run_after_each) {
-              context->run_after_eaches();
-            }
+            func();
+            success = true;
           });
 
-          if (success) {
-            reporter->it_succeeded(desc);
-          }
-        });
+          try_with_adapter(desc, success, [&] {
+            bool do_run_after_each = false;
+            std::for_each(context_stack.rbegin(), context_stack.rend(), [&](context::interface* context) {
+              if (context == last_successful_before_each_context) {
+                do_run_after_each = true;
+              }
+              if (do_run_after_each) {
+                context->run_after_eaches();
+              }
+            });
+
+            if (success) {
+              reporter->it_succeeded(desc);
+            }
+          });
+        }
       }
 
       // A function is required to initialize a static settings variable in a header file
@@ -154,6 +128,30 @@ namespace bandit {
       static settings_t*& get_settings_address() {
         static settings_t* settings_ = nullptr;
         return settings_;
+      }
+
+      void try_with_adapter(const std::string& desc, bool allow_fail, std::function<void()> do_it) {
+        if (allow_fail) {
+          try {
+            adapter->adapt_exceptions([&] { do_it(); });
+          } catch (const bandit::detail::assertion_exception& ex) {
+            reporter->it_failed(desc, ex);
+            run_policy->encountered_failure();
+          } catch (const std::exception& ex) {
+            std::string err = std::string("exception: ") + ex.what();
+            reporter->it_failed(desc, bandit::detail::assertion_exception(err));
+            run_policy->encountered_failure();
+          } catch (...) {
+            reporter->it_unknown_error(desc);
+            run_policy->encountered_failure();
+          }
+        } else {
+          try {
+            do_it();
+          } catch (...) {
+            /* ignore */
+          }
+        }
       }
 
       colorizer_ptr create_colorizer(const options& opt) const {

--- a/bandit/settings.h
+++ b/bandit/settings.h
@@ -2,23 +2,15 @@
 #define BANDIT_SETTINGS_H
 
 #include <bandit/adapters.h>
-#include <bandit/colorizers.h>
-#include <bandit/failure_formatters.h>
-#include <bandit/options.h>
-#include <bandit/reporters.h>
-#include <bandit/run_policies.h>
+#include <bandit/colorizers/interface.h>
+#include <bandit/failure_formatters/interface.h>
+#include <bandit/reporters/interface.h>
+#include <bandit/run_policies/interface.h>
 
 namespace bandit {
   namespace detail {
     struct settings_t {
-      settings_t(const options& opt)
-          : adapter(new adapter::snowhouse),
-            colorizer(create_colorizer(opt)),
-            formatter(create_formatter(opt)),
-            reporter(create_reporter(opt)),
-            run_policy(new run_policy::bandit(opt.filter_chain(), opt.break_on_failure(), opt.dry_run())) {}
-
-      settings_t() : settings_t(options(0, nullptr)) {}
+      settings_t() : adapter(new adapter::snowhouse) {}
 
       context::stack_t& get_contexts() {
         return context_stack;
@@ -30,6 +22,22 @@ namespace bandit {
 
       void set_adapter(assertion_adapter_t* adapter_) {
         adapter.reset(adapter_);
+      }
+
+      colorizer_t& get_colorizer() {
+        return *colorizer;
+      }
+
+      void set_colorizer(colorizer_t* colorizer_) {
+        colorizer.reset(colorizer_);
+      }
+
+      failure_formatter_t& get_formatter() {
+        return *formatter;
+      }
+
+      void set_formatter(failure_formatter_t* formatter_) {
+        formatter.reset(formatter_);
       }
 
       reporter_t& get_reporter() {
@@ -161,46 +169,6 @@ namespace bandit {
           } catch (...) {
             /* ignore */
           }
-        }
-      }
-
-      colorizer_t* create_colorizer(const options& opt) const {
-        switch (opt.colorizer()) {
-        case options::colorizers::OFF:
-          return new colorizer::off();
-        case options::colorizers::DARK:
-          return new colorizer::dark();
-        case options::colorizers::LIGHT:
-        default:
-          return new colorizer::light();
-        }
-      }
-
-      failure_formatter_t* create_formatter(const options& opt) const {
-        switch (opt.formatter()) {
-        case options::formatters::VS:
-          return new failure_formatter::visual_studio();
-        case options::formatters::POSIX:
-        default:
-          return new failure_formatter::posix();
-        }
-      }
-
-      reporter_t* create_reporter(const options& opt) const {
-        switch (opt.reporter()) {
-        case options::reporters::SINGLELINE:
-          return new bandit::reporter::singleline(*formatter, *colorizer);
-        case options::reporters::XUNIT:
-          return new bandit::reporter::xunit(*formatter);
-        case options::reporters::INFO:
-          return new bandit::reporter::info(*formatter, *colorizer);
-        case options::reporters::SPEC:
-          return new bandit::reporter::spec(*formatter, *colorizer);
-        case options::reporters::CRASH:
-          return new bandit::reporter::crash(*formatter);
-        case options::reporters::DOTS:
-        default:
-          return new bandit::reporter::dots(*formatter, *colorizer);
         }
       }
 

--- a/bandit/settings.h
+++ b/bandit/settings.h
@@ -17,6 +17,7 @@ namespace bandit {
       }
 
       assertion_adapter_t& get_adapter() {
+        throw_if_nullptr(adapter.get(), "assertion adapter", "bandit::detail::settings_t::set_adapter()");
         return *adapter;
       }
 
@@ -25,6 +26,7 @@ namespace bandit {
       }
 
       colorizer_t& get_colorizer() {
+        throw_if_nullptr(colorizer.get(), "colorizer", "bandit::detail::settings_t::set_colorizer()");
         return *colorizer;
       }
 
@@ -33,6 +35,7 @@ namespace bandit {
       }
 
       failure_formatter_t& get_formatter() {
+        throw_if_nullptr(formatter.get(), "formatter", "bandit::detail::settings_t::set_formatter()");
         return *formatter;
       }
 
@@ -41,6 +44,7 @@ namespace bandit {
       }
 
       reporter_t& get_reporter() {
+        throw_if_nullptr(reporter.get(), "reporter", "bandit::detail::settings_t::set_reporter()");
         return *reporter;
       }
 
@@ -49,6 +53,7 @@ namespace bandit {
       }
 
       run_policy_t& get_policy() {
+        throw_if_nullptr(run_policy.get(), "run policy", "bandit::detail::settings_t::set_policy()");
         return *run_policy;
       }
 
@@ -127,18 +132,14 @@ namespace bandit {
       // and this struct aims at encapsulating this function
       static void register_settings(settings_t* settings) {
         if (settings == nullptr) {
-          throw std::runtime_error("Invalid null settings passed to "
-                                   "bandit::detail::register_settings");
+          throw std::runtime_error("Invalid null settings passed to bandit::detail::register_settings()");
         }
         get_settings_address() = settings;
       }
 
       static settings_t& registered_settings() {
         auto settings = get_settings_address();
-        if (settings == nullptr) {
-          throw std::runtime_error("No settings set. Please call "
-                                   "bandit::detail::register_settings with a non-null settings");
-        }
+        throw_if_nullptr(settings, "settings", "bandit::detail::register_settings()");
         return *settings;
       }
 
@@ -146,6 +147,12 @@ namespace bandit {
       static settings_t*& get_settings_address() {
         static settings_t* settings_ = nullptr;
         return settings_;
+      }
+
+      static void throw_if_nullptr(const void* ptr, const std::string& name, const std::string& setter) {
+        if (ptr == nullptr) {
+          throw std::runtime_error("No " + name + " set. Please set it using " + setter);
+        }
       }
 
       void try_with_adapter(const std::string& desc, bool allow_fail, std::function<void()> do_it) {

--- a/bandit/settings.h
+++ b/bandit/settings.h
@@ -67,6 +67,16 @@ namespace bandit {
         reporter->context_ended(desc);
       }
 
+      void before_each(std::function<void()> func) {
+        context_stack.throw_if_empty("before_each");
+        context_stack.back()->register_before_each(func);
+      }
+
+      void after_each(std::function<void()> func) {
+        context_stack.throw_if_empty("after_each");
+        context_stack.back()->register_after_each(func);
+      }
+
       void it(const std::string& desc, std::function<void()> func, bool hard_skip) {
         context_stack.throw_if_empty("it");
         if (hard_skip || !run_policy->should_run(desc, context_stack)) {

--- a/bandit/settings.h
+++ b/bandit/settings.h
@@ -1,6 +1,7 @@
 #ifndef BANDIT_SETTINGS_H
 #define BANDIT_SETTINGS_H
 
+#include <bandit/adapters.h>
 #include <bandit/colorizers.h>
 #include <bandit/failure_formatters.h>
 #include <bandit/options.h>
@@ -10,16 +11,22 @@
 namespace bandit {
   namespace detail {
     struct settings_t {
+      assertion_adapter_ptr adapter;
       colorizer_ptr colorizer;
       failure_formatter_ptr formatter;
       reporter_ptr reporter;
       run_policy_ptr run_policy;
 
       settings_t(const options& opt)
-          : colorizer(create_colorizer(opt)),
+          : adapter(new adapter::snowhouse),
+            colorizer(create_colorizer(opt)),
             formatter(create_formatter(opt)),
             reporter(create_reporter(opt)),
             run_policy(new run_policy::bandit(opt.filter_chain(), opt.break_on_failure(), opt.dry_run())) {}
+
+      assertion_adapter_t& get_adapter() {
+        return *adapter;
+      }
 
       reporter_t& get_reporter() {
         return *reporter;

--- a/bandit/settings.h
+++ b/bandit/settings.h
@@ -61,7 +61,7 @@ namespace bandit {
         run_policy.reset(run_policy_);
       }
 
-      void describe(const std::string& desc, std::function<void()> func, bool hard_skip) {
+      void describe(const std::string& desc, const std::function<void()>& func, bool hard_skip) {
         reporter->context_starting(desc);
 
         context_stack.back()->execution_is_starting();
@@ -80,17 +80,17 @@ namespace bandit {
         reporter->context_ended(desc);
       }
 
-      void before_each(std::function<void()> func) {
+      void before_each(const std::function<void()>& func) {
         context_stack.throw_if_empty("before_each");
         context_stack.back()->register_before_each(func);
       }
 
-      void after_each(std::function<void()> func) {
+      void after_each(const std::function<void()>& func) {
         context_stack.throw_if_empty("after_each");
         context_stack.back()->register_after_each(func);
       }
 
-      void it(const std::string& desc, std::function<void()> func, bool hard_skip) {
+      void it(const std::string& desc, const std::function<void()>& func, bool hard_skip) {
         context_stack.throw_if_empty("it");
         if (hard_skip || !run_policy->should_run(desc, context_stack)) {
           reporter->it_skip(desc);
@@ -155,7 +155,7 @@ namespace bandit {
         }
       }
 
-      void try_with_adapter(const std::string& desc, bool allow_fail, std::function<void()> do_it) {
+      void try_with_adapter(const std::string& desc, bool allow_fail, const std::function<void()>& do_it) {
         if (allow_fail) {
           try {
             adapter->adapt_exceptions([&] { do_it(); });

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -29,7 +29,7 @@ In the following, we list breaking changes per major release.
   allows to write description-generating code more nicely and
   the latter eases skipping (or not) based on the program flow.
 
-* The grammar and runner now use `bandit::detail::settings_t` as optional parameters
+* The grammar and runner now use `bandit::detail::controller_t` as optional parameters
   instead of reporters, run policies, etc. This is a change of the public
   API that is probably only of internal interest.
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -18,14 +18,18 @@ In the following, we list breaking changes per major release.
   or all tests were skipped. Now the exit code is `0` in these cases because
   no tests are failing.
 
-* The signature of the short grammar of `it` and `describe` became a third
-  (but optional) parameter: if the `it`/`describe` should be skipped or not.
+* The signatures of the grammar functions (`it()`, `describe()`,
+  `before_each()`, etc.) have changed.
+  For `it()` and `describe()` (and their skipping counterparts),
+  the first parameter (the description) is now a `const std::string&`
+  instead of `const char*`.
+  `it()` and `describe()` also got an optional third parameter that says
+  if it should be skipped or not.
+  Both changes should not break any sane existing code but the former
+  allows to write description-generating code more nicely and
+  the latter eases skipping (or not) based on the program flow.
 
-* The grammar now uses `const std::string&` as description type instead of
-  `const char*`. This should not break any existing code but you can write
-  description-generating code more nicely.
-
-* The grammar now uses `bandit::detail::settings_t` as optional parameters
+* The grammar and runner now use `bandit::detail::settings_t` as optional parameters
   instead of reporters, run policies, etc. This is a change of the public
   API that is probably only of internal interest.
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -25,6 +25,10 @@ In the following, we list breaking changes per major release.
   `const char*`. This should not break any existing code but you can write
   description-generating code more nicely.
 
+* The grammar now uses `bandit::detail::settings_t` as optional parameters
+  instead of reporters, run policies, etc. This is a change of the public
+  API that is probably only of internal interest.
+
 * The behavior of combined `--only` and `--skip` has changed.
   You can now use these switches multiple times and they always act as a filter,
   that is, you can only reduce the list of tests by adding a `--only` or `--skip`

--- a/specs/before_each_after_each.cpp
+++ b/specs/before_each_after_each.cpp
@@ -3,13 +3,13 @@
 
 go_bandit([]() {
   describe("before_each/after_each", [&]() {
-    std::unique_ptr<bandit::detail::settings_t> settings;
+    std::unique_ptr<bandit::detail::controller_t> controller;
     std::unique_ptr<fakes::fake_context> context;
 
     before_each([&]() {
-      settings.reset(new bandit::detail::settings_t());
+      controller.reset(new bandit::detail::controller_t());
       context = std::unique_ptr<fakes::fake_context>(new fakes::fake_context());
-      settings->get_contexts().push_back(context.get());
+      controller->get_contexts().push_back(context.get());
     });
 
     describe("before_each", [&]() {
@@ -20,13 +20,13 @@ go_bandit([]() {
       });
 
       it("registers itself for the current context in the stack", [&]() {
-        before_each(before_each_fn, *settings);
+        before_each(before_each_fn, *controller);
         AssertThat(context->call_log(), Has().Exactly(1).EqualTo("register_before_each"));
       });
 
       it("does not work without context", [&] {
-        settings->get_contexts().pop_back();
-        AssertThrows(bandit::detail::test_run_error, before_each(before_each_fn, *settings));
+        controller->get_contexts().pop_back();
+        AssertThrows(bandit::detail::test_run_error, before_each(before_each_fn, *controller));
         AssertThat(LastException<bandit::detail::test_run_error>().what(),
             Equals("'before_each' was called without surrounding 'describe'"));
       });
@@ -40,13 +40,13 @@ go_bandit([]() {
       });
 
       it("registers itself for the current context in the stack", [&]() {
-        after_each(after_each_fn, *settings);
+        after_each(after_each_fn, *controller);
         AssertThat(context->call_log(), Has().Exactly(1).EqualTo("register_after_each"));
       });
 
       it("does not work without context", [&] {
-        settings->get_contexts().pop_back();
-        AssertThrows(bandit::detail::test_run_error, after_each(after_each_fn, *settings));
+        controller->get_contexts().pop_back();
+        AssertThrows(bandit::detail::test_run_error, after_each(after_each_fn, *controller));
         AssertThat(LastException<bandit::detail::test_run_error>().what(),
             Equals("'after_each' was called without surrounding 'describe'"));
       });

--- a/specs/describe.cpp
+++ b/specs/describe.cpp
@@ -9,20 +9,20 @@ SPEC_BEGIN(describe)
 describe("describe", []() {
   std::function<void()> describe_fn;
   fake_reporter* reporter;
-  std::unique_ptr<bandit::detail::settings_t> settings;
+  std::unique_ptr<bandit::detail::controller_t> controller;
   std::unique_ptr<fake_context> global_context;
 
   before_each([&]() {
     reporter = new fake_reporter();
-    settings.reset(new bandit::detail::settings_t());
-    settings->set_reporter(reporter);
+    controller.reset(new bandit::detail::controller_t());
+    controller->set_reporter(reporter);
 
     global_context = std::unique_ptr<fake_context>(new fake_context());
-    settings->get_contexts().push_back(global_context.get());
+    controller->get_contexts().push_back(global_context.get());
   });
 
   auto call_describe = [&]() {
-    describe("context name", describe_fn, false, *settings);
+    describe("context name", describe_fn, false, *controller);
   };
 
   describe("with a succeeding 'it'", [&]() {
@@ -30,7 +30,7 @@ describe("describe", []() {
 
     before_each([&]() {
       context_stack_size_while_running = 0;
-      describe_fn = [&]() { context_stack_size_while_running = settings->get_contexts().size(); };
+      describe_fn = [&]() { context_stack_size_while_running = controller->get_contexts().size(); };
     });
 
     it("tells its parent context that execution has started", [&]() {
@@ -59,7 +59,7 @@ describe("describe", []() {
 
     it("pops the context from the stack after execution so that only the global context is left", [&]() {
       call_describe();
-      AssertThat(settings->get_contexts(), Is().OfLength(1));
+      AssertThat(controller->get_contexts(), Is().OfLength(1));
     });
 
   });
@@ -86,7 +86,7 @@ describe("describe", []() {
   describe("skip", [&]() {
     bool context_is_hard_skip;
     describe_fn = [&]() {
-      context_is_hard_skip = settings->get_contexts().back()->hard_skip();
+      context_is_hard_skip = controller->get_contexts().back()->hard_skip();
     };
 
     before_each([&]() {
@@ -95,14 +95,14 @@ describe("describe", []() {
 
     describe("describe_skip", [&]() {
       it("pushes a context marked as skipped on the stack", [&]() {
-        describe_skip("context name", describe_fn, *settings);
+        describe_skip("context name", describe_fn, *controller);
         AssertThat(context_is_hard_skip, IsTrue());
       });
     });
 
     describe("xdescribe", [&]() {
       it("pushes a context marked as skipped on the stack", [&]() {
-        xdescribe("context name", describe_fn, *settings);
+        xdescribe("context name", describe_fn, *controller);
         AssertThat(context_is_hard_skip, IsTrue());
       });
     });

--- a/specs/describe.cpp
+++ b/specs/describe.cpp
@@ -22,7 +22,7 @@ describe("describe", []() {
   });
 
   auto call_describe = [&]() {
-    describe("context name", describe_fn, *settings);
+    describe("context name", describe_fn, false, *settings);
   };
 
   describe("with a succeeding 'it'", [&]() {

--- a/specs/describe.cpp
+++ b/specs/describe.cpp
@@ -8,12 +8,14 @@ SPEC_BEGIN(describe)
 
 describe("describe", []() {
   std::function<void()> describe_fn;
-  fake_reporter_ptr reporter;
+  fake_reporter* reporter;
+  bandit::detail::settings_t settings;
   std::unique_ptr<bandit::context::stack_t> context_stack;
   std::unique_ptr<fake_context> global_context;
 
   before_each([&]() {
-    reporter = fake_reporter_ptr(new fake_reporter());
+    reporter = new fake_reporter();
+    settings.set_reporter(reporter);
 
     context_stack = std::unique_ptr<bandit::context::stack_t>(new bandit::context::stack_t());
 
@@ -22,7 +24,7 @@ describe("describe", []() {
   });
 
   auto call_describe = [&]() {
-    describe("context name", describe_fn, *reporter, *context_stack);
+    describe("context name", describe_fn, settings, *context_stack);
   };
 
   describe("with a succeeding 'it'", [&]() {
@@ -95,14 +97,14 @@ describe("describe", []() {
 
     describe("describe_skip", [&]() {
       it("pushes a context marked as skipped on the stack", [&]() {
-        describe_skip("context name", describe_fn, *reporter, *context_stack);
+        describe_skip("context name", describe_fn, settings, *context_stack);
         AssertThat(context_is_hard_skip, IsTrue());
       });
     });
 
     describe("xdescribe", [&]() {
       it("pushes a context marked as skipped on the stack", [&]() {
-        xdescribe("context name", describe_fn, *reporter, *context_stack);
+        xdescribe("context name", describe_fn, settings, *context_stack);
         AssertThat(context_is_hard_skip, IsTrue());
       });
     });

--- a/specs/fakes/fake_reporter.h
+++ b/specs/fakes/fake_reporter.h
@@ -61,8 +61,6 @@ namespace bandit {
     private:
       bool test_run_status_;
     };
-
-    using fake_reporter_ptr = std::unique_ptr<fake_reporter>;
   }
 }
 #endif

--- a/specs/it.cpp
+++ b/specs/it.cpp
@@ -9,21 +9,21 @@ go_bandit([]() {
   describe("it", [&]() {
     std::function<void()> it_func;
     fake_reporter* reporter;
-    std::unique_ptr<bandit::detail::settings_t> settings;
+    std::unique_ptr<bandit::detail::controller_t> controller;
     std::unique_ptr<fake_context> context;
 
     before_each([&]() {
       reporter = new fake_reporter();
-      settings.reset(new bandit::detail::settings_t());
-      settings->set_reporter(reporter);
+      controller.reset(new bandit::detail::controller_t());
+      controller->set_reporter(reporter);
       context = std::unique_ptr<fake_context>(new fake_context());
-      settings->get_contexts().push_back(context.get());
+      controller->get_contexts().push_back(context.get());
 
-      settings->set_policy(new run_policy::always());
+      controller->set_policy(new run_policy::always());
     });
 
     auto call_it = [&]() {
-      it("my it", it_func, false, *settings);
+      it("my it", it_func, false, *controller);
     };
 
     it("tells the current context that execution has started", [&]() {
@@ -36,7 +36,7 @@ go_bandit([]() {
     });
 
     it("does not work without context", [&] {
-      settings->get_contexts().pop_back();
+      controller->get_contexts().pop_back();
       AssertThrows(bandit::detail::test_run_error, call_it());
       AssertThat(LastException<bandit::detail::test_run_error>().what(),
           Equals("'it' was called without surrounding 'describe'"));
@@ -85,7 +85,7 @@ go_bandit([]() {
 
         it("tells run_policy that we have a failing test", [&]() {
           call_it();
-          AssertThat(settings->get_policy().has_encountered_failure(), IsTrue());
+          AssertThat(controller->get_policy().has_encountered_failure(), IsTrue());
         });
       });
 
@@ -106,7 +106,7 @@ go_bandit([]() {
 
         it("tells run_policy that we have a failing test", [&]() {
           call_it();
-          AssertThat(settings->get_policy().has_encountered_failure(), IsTrue());
+          AssertThat(controller->get_policy().has_encountered_failure(), IsTrue());
         });
       });
 
@@ -127,7 +127,7 @@ go_bandit([]() {
 
         it("tells run_policy that we have a failing test", [&]() {
           call_it();
-          AssertThat(settings->get_policy().has_encountered_failure(), IsTrue());
+          AssertThat(controller->get_policy().has_encountered_failure(), IsTrue());
         });
       });
 
@@ -149,7 +149,7 @@ go_bandit([]() {
 
         it("tells run_policy that we have a failing test", [&]() {
           call_it();
-          AssertThat(settings->get_policy().has_encountered_failure(), IsTrue());
+          AssertThat(controller->get_policy().has_encountered_failure(), IsTrue());
         });
       });
 
@@ -170,7 +170,7 @@ go_bandit([]() {
 
         it("tells run_policy that we have a failing test", [&]() {
           call_it();
-          AssertThat(settings->get_policy().has_encountered_failure(), IsTrue());
+          AssertThat(controller->get_policy().has_encountered_failure(), IsTrue());
         });
       });
 
@@ -191,7 +191,7 @@ go_bandit([]() {
 
         it("tells run_policy that we have a failing test", [&]() {
           call_it();
-          AssertThat(settings->get_policy().has_encountered_failure(), IsTrue());
+          AssertThat(controller->get_policy().has_encountered_failure(), IsTrue());
         });
       });
     });
@@ -219,7 +219,7 @@ go_bandit([]() {
 
       it("tells run_policy that we have a failing test", [&]() {
         call_it();
-        AssertThat(settings->get_policy().has_encountered_failure(), IsTrue());
+        AssertThat(controller->get_policy().has_encountered_failure(), IsTrue());
       });
     });
 
@@ -245,7 +245,7 @@ go_bandit([]() {
 
       it("tells run_policy that we have a failing test", [&]() {
         call_it();
-        AssertThat(settings->get_policy().has_encountered_failure(), IsTrue());
+        AssertThat(controller->get_policy().has_encountered_failure(), IsTrue());
       });
     });
 
@@ -271,32 +271,32 @@ go_bandit([]() {
 
       it("tells run_policy that we have a failing test", [&]() {
         call_it();
-        AssertThat(settings->get_policy().has_encountered_failure(), IsTrue());
+        AssertThat(controller->get_policy().has_encountered_failure(), IsTrue());
       });
     });
 
     describe("it_skip", [&]() {
       it("tells reporter it's skipped", [&]() {
-        it_skip("my it", []() {}, *settings);
+        it_skip("my it", []() {}, *controller);
         AssertThat(reporter->call_log(), Has().Exactly(1).EqualTo("it_skip: my it"));
       });
 
       it("doesn't call function", [&]() {
         bool called = false;
-        it_skip("my it", [&]() { called = true; }, *settings);
+        it_skip("my it", [&]() { called = true; }, *controller);
         AssertThat(called, IsFalse());
       });
     });
 
     describe("xit", [&]() {
       it("tells reporter it's skipped", [&]() {
-        xit("my it", []() {}, *settings);
+        xit("my it", []() {}, *controller);
         AssertThat(reporter->call_log(), Has().Exactly(1).EqualTo("it_skip: my it"));
       });
 
       it("doesn't call function", [&]() {
         bool called = false;
-        xit("my it", [&]() { called = true; }, *settings);
+        xit("my it", [&]() { called = true; }, *controller);
         AssertThat(called, IsFalse());
       });
     });
@@ -305,7 +305,7 @@ go_bandit([]() {
       bool it_was_called;
 
       before_each([&]() {
-        settings->set_policy(new run_policy::never());
+        controller->set_policy(new run_policy::never());
         it_func = [&]() { it_was_called = true; };
         it_was_called = false;
       });
@@ -331,7 +331,7 @@ go_bandit([]() {
 
       describe("with a policy that says to skip this it", [&]() {
         before_each([&]() {
-          settings->set_policy(new run_policy::never());
+          controller->set_policy(new run_policy::never());
         });
 
         it("tells reporter it's skipped", [&]() {

--- a/specs/it.cpp
+++ b/specs/it.cpp
@@ -278,26 +278,26 @@ go_bandit([]() {
 
     describe("it_skip", [&]() {
       it("tells reporter it's skipped", [&]() {
-        it_skip("my it", []() {}, *reporter);
+        it_skip("my it", []() {}, settings);
         AssertThat(reporter->call_log(), Has().Exactly(1).EqualTo("it_skip: my it"));
       });
 
       it("doesn't call function", [&]() {
         bool called = false;
-        it_skip("my it", [&]() { called = true; }, *reporter);
+        it_skip("my it", [&]() { called = true; }, settings);
         AssertThat(called, IsFalse());
       });
     });
 
     describe("xit", [&]() {
       it("tells reporter it's skipped", [&]() {
-        xit("my it", []() {}, *reporter);
+        xit("my it", []() {}, settings);
         AssertThat(reporter->call_log(), Has().Exactly(1).EqualTo("it_skip: my it"));
       });
 
       it("doesn't call function", [&]() {
         bool called = false;
-        xit("my it", [&]() { called = true; }, *reporter);
+        xit("my it", [&]() { called = true; }, settings);
         AssertThat(called, IsFalse());
       });
     });

--- a/specs/it.cpp
+++ b/specs/it.cpp
@@ -8,23 +8,23 @@ namespace bd = bandit::detail;
 go_bandit([]() {
   describe("it", [&]() {
     std::function<void()> it_func;
-    fake_reporter_ptr reporter;
+    fake_reporter* reporter;
+    bd::settings_t settings;
     std::unique_ptr<context::stack_t> contexts;
     std::unique_ptr<fake_context> context;
-    adapter::snowhouse assertion_adapter;
-    bd::run_policy_ptr run_policy;
 
     before_each([&]() {
-      reporter = fake_reporter_ptr(new fake_reporter());
+      reporter = new fake_reporter();
+      settings.set_reporter(reporter);
       contexts = std::unique_ptr<bandit::context::stack_t>(new bandit::context::stack_t());
       context = std::unique_ptr<fake_context>(new fake_context());
       contexts->push_back(context.get());
 
-      run_policy = bd::run_policy_ptr(new run_policy::always());
+      settings.set_policy(new run_policy::always());
     });
 
     auto call_it = [&]() {
-      it("my it", it_func, *reporter, *contexts, assertion_adapter, *run_policy);
+      it("my it", it_func, settings, *contexts);
     };
 
     it("tells the current context that execution has started", [&]() {
@@ -86,7 +86,7 @@ go_bandit([]() {
 
         it("tells run_policy that we have a failing test", [&]() {
           call_it();
-          AssertThat(run_policy->has_encountered_failure(), IsTrue());
+          AssertThat(settings.get_policy().has_encountered_failure(), IsTrue());
         });
       });
 
@@ -107,7 +107,7 @@ go_bandit([]() {
 
         it("tells run_policy that we have a failing test", [&]() {
           call_it();
-          AssertThat(run_policy->has_encountered_failure(), IsTrue());
+          AssertThat(settings.get_policy().has_encountered_failure(), IsTrue());
         });
       });
 
@@ -128,7 +128,7 @@ go_bandit([]() {
 
         it("tells run_policy that we have a failing test", [&]() {
           call_it();
-          AssertThat(run_policy->has_encountered_failure(), IsTrue());
+          AssertThat(settings.get_policy().has_encountered_failure(), IsTrue());
         });
       });
 
@@ -150,7 +150,7 @@ go_bandit([]() {
 
         it("tells run_policy that we have a failing test", [&]() {
           call_it();
-          AssertThat(run_policy->has_encountered_failure(), IsTrue());
+          AssertThat(settings.get_policy().has_encountered_failure(), IsTrue());
         });
       });
 
@@ -171,7 +171,7 @@ go_bandit([]() {
 
         it("tells run_policy that we have a failing test", [&]() {
           call_it();
-          AssertThat(run_policy->has_encountered_failure(), IsTrue());
+          AssertThat(settings.get_policy().has_encountered_failure(), IsTrue());
         });
       });
 
@@ -192,7 +192,7 @@ go_bandit([]() {
 
         it("tells run_policy that we have a failing test", [&]() {
           call_it();
-          AssertThat(run_policy->has_encountered_failure(), IsTrue());
+          AssertThat(settings.get_policy().has_encountered_failure(), IsTrue());
         });
       });
     });
@@ -220,7 +220,7 @@ go_bandit([]() {
 
       it("tells run_policy that we have a failing test", [&]() {
         call_it();
-        AssertThat(run_policy->has_encountered_failure(), IsTrue());
+        AssertThat(settings.get_policy().has_encountered_failure(), IsTrue());
       });
     });
 
@@ -246,7 +246,7 @@ go_bandit([]() {
 
       it("tells run_policy that we have a failing test", [&]() {
         call_it();
-        AssertThat(run_policy->has_encountered_failure(), IsTrue());
+        AssertThat(settings.get_policy().has_encountered_failure(), IsTrue());
       });
     });
 
@@ -272,7 +272,7 @@ go_bandit([]() {
 
       it("tells run_policy that we have a failing test", [&]() {
         call_it();
-        AssertThat(run_policy->has_encountered_failure(), IsTrue());
+        AssertThat(settings.get_policy().has_encountered_failure(), IsTrue());
       });
     });
 
@@ -306,7 +306,7 @@ go_bandit([]() {
       bool it_was_called;
 
       before_each([&]() {
-        run_policy = bd::run_policy_ptr(new run_policy::never());
+        settings.set_policy(new run_policy::never());
         it_func = [&]() { it_was_called = true; };
         it_was_called = false;
       });
@@ -332,7 +332,7 @@ go_bandit([]() {
 
       describe("with a policy that says to skip this it", [&]() {
         before_each([&]() {
-          run_policy = bd::run_policy_ptr(new run_policy::never());
+          settings.set_policy(new run_policy::never());
         });
 
         it("tells reporter it's skipped", [&]() {

--- a/specs/it.cpp
+++ b/specs/it.cpp
@@ -23,7 +23,7 @@ go_bandit([]() {
     });
 
     auto call_it = [&]() {
-      it("my it", it_func, *settings);
+      it("my it", it_func, false, *settings);
     };
 
     it("tells the current context that execution has started", [&]() {

--- a/specs/options.cpp
+++ b/specs/options.cpp
@@ -149,10 +149,10 @@ go_bandit([]() {
         });
 
         using slpair = std::pair<std::string, std::vector<std::string>>;
-        for (auto pair : std::initializer_list<slpair>{
-              {"colorizer", {"off", "dark", "light"}},
-              {"formatter", {"posix", "vs"}},
-              {"reporter", {"singleline", "xunit", "info", "spec", "crash", "dots"}}}) {
+        for (auto pair : {
+              slpair{"colorizer", {"off", "dark", "light"}},
+              slpair{"formatter", {"posix", "vs"}},
+              slpair{"reporter", {"singleline", "xunit", "info", "spec", "crash", "dots"}}}) {
           for (std::string name : pair.second) {
             it("works with known " + pair.first + " '" + name + "'", [&] {
               error_collector cerr;

--- a/specs/options.cpp
+++ b/specs/options.cpp
@@ -150,9 +150,9 @@ go_bandit([]() {
 
         using slpair = std::pair<std::string, std::vector<std::string>>;
         for (auto pair : {
-              slpair{"colorizer", {"off", "dark", "light"}},
-              slpair{"formatter", {"posix", "vs"}},
-              slpair{"reporter", {"singleline", "xunit", "info", "spec", "crash", "dots"}}}) {
+                 slpair{"colorizer", {"off", "dark", "light"}},
+                 slpair{"formatter", {"posix", "vs"}},
+                 slpair{"reporter", {"singleline", "xunit", "info", "spec", "crash", "dots"}}}) {
           for (std::string name : pair.second) {
             it("works with known " + pair.first + " '" + name + "'", [&] {
               error_collector cerr;

--- a/specs/options.cpp
+++ b/specs/options.cpp
@@ -122,16 +122,16 @@ go_bandit([]() {
       });
     });
 
-    describe("update_settings()", [&] {
-      std::unique_ptr<bd::settings_t> settings;
+    describe("update_controller_settings()", [&] {
+      std::unique_ptr<bd::controller_t> controller;
 
       before_each([&] {
-        settings.reset(new bd::settings_t);
+        controller.reset(new bd::controller_t);
       });
 
       it("throws exception if no choice_options given", [&] {
         options opt({});
-        AssertThrows(std::runtime_error, opt.update_settings(*settings));
+        AssertThrows(std::runtime_error, opt.update_controller_settings(*controller));
       });
 
       describe("with default choice_options", [&] {
@@ -144,7 +144,7 @@ go_bandit([]() {
 
         it("works without any options default choice_options given", [&] {
           options opt({}, *copts);
-          AssertThat(opt.update_settings(*settings), IsTrue());
+          AssertThat(opt.update_controller_settings(*controller), IsTrue());
           all_ok(opt);
         });
 
@@ -157,7 +157,7 @@ go_bandit([]() {
             it("works with known " + pair.first + " '" + name + "'", [&] {
               error_collector cerr;
               options opt({"--" + pair.first, name}, *copts);
-              AssertThat(opt.update_settings(*settings), IsTrue());
+              AssertThat(opt.update_controller_settings(*controller), IsTrue());
               all_ok(opt);
               AssertThat(cerr.get(), IsEmpty());
             });
@@ -168,7 +168,7 @@ go_bandit([]() {
             options opt({"--" + pair.first + "=__unknown__"}, *copts);
             all_ok(opt);
             AssertThat(cerr.get(), IsEmpty());
-            AssertThat(opt.update_settings(*settings), IsFalse());
+            AssertThat(opt.update_controller_settings(*controller), IsFalse());
             AssertThat(opt.parsed_ok(), IsFalse());
             AssertThat(cerr.get(), Contains("Unknown"));
             AssertThat(cerr.get(), Contains(pair.first));

--- a/specs/run.cpp
+++ b/specs/run.cpp
@@ -12,24 +12,24 @@ go_bandit([]() {
     std::unique_ptr<bd::spec_registry> specs;
     std::unique_ptr<argv_helper> argv;
     fake_reporter* reporter;
-    std::unique_ptr<bd::settings_t> settings;
+    std::unique_ptr<bd::controller_t> controller;
 
     auto call_run = [&]() -> int {
       bd::options opt(argv->argc(), argv->argv());
-      return run(opt, *specs, *settings);
+      return run(opt, *specs, *controller);
     };
 
     before_each([&]() {
       specs.reset(new bd::spec_registry());
       reporter = new fake_reporter();
-      settings.reset(new bd::settings_t());
-      settings->set_reporter(reporter);
+      controller.reset(new bd::controller_t());
+      controller->set_reporter(reporter);
       argv.reset(new argv_helper({}));
     });
 
     it("pushes the global context on the context stack", [&]() {
       call_run();
-      AssertThat(settings->get_contexts(), Is().OfLength(1));
+      AssertThat(controller->get_contexts(), Is().OfLength(1));
     });
 
     describe("a successful test run", [&]() {

--- a/specs/run.cpp
+++ b/specs/run.cpp
@@ -12,25 +12,24 @@ go_bandit([]() {
     std::unique_ptr<bd::spec_registry> specs;
     std::unique_ptr<argv_helper> argv;
     fake_reporter* reporter;
-    bd::settings_t settings;
-    std::unique_ptr<context::stack_t> context_stack;
+    std::unique_ptr<bd::settings_t> settings;
 
     auto call_run = [&]() -> int {
       bd::options opt(argv->argc(), argv->argv());
-      return run(opt, *specs, *context_stack, settings);
+      return run(opt, *specs, *settings);
     };
 
     before_each([&]() {
       specs.reset(new bd::spec_registry());
       reporter = new fake_reporter();
-      settings.set_reporter(reporter);
-      context_stack.reset(new context::stack_t());
+      settings.reset(new bd::settings_t());
+      settings->set_reporter(reporter);
       argv.reset(new argv_helper({}));
     });
 
     it("pushes the global context on the context stack", [&]() {
       call_run();
-      AssertThat(*context_stack, Is().OfLength(1));
+      AssertThat(settings->get_contexts(), Is().OfLength(1));
     });
 
     describe("a successful test run", [&]() {

--- a/specs/run.cpp
+++ b/specs/run.cpp
@@ -11,17 +11,19 @@ go_bandit([]() {
   describe("run", [&]() {
     std::unique_ptr<bd::spec_registry> specs;
     std::unique_ptr<argv_helper> argv;
-    fake_reporter_ptr reporter;
+    fake_reporter* reporter;
+    bd::settings_t settings;
     std::unique_ptr<context::stack_t> context_stack;
 
     auto call_run = [&]() -> int {
       bd::options opt(argv->argc(), argv->argv());
-      return run(opt, *specs, *context_stack, *reporter);
+      return run(opt, *specs, *context_stack, settings);
     };
 
     before_each([&]() {
       specs.reset(new bd::spec_registry());
-      reporter.reset(new fake_reporter());
+      reporter = new fake_reporter();
+      settings.set_reporter(reporter);
       context_stack.reset(new context::stack_t());
       argv.reset(new argv_helper({}));
     });


### PR DESCRIPTION
This is an attempt to make the internals of bandit more flexible.
The purpose of `controller_t` is to contain all the important things, like
assertion framework, colorizer, failure formatter, reporter, run policy,
and what else may come in the future. Now all our grammar is based
on this type (and the static/inline grammar functions now call the according
`controller_t` methods, hence the name).

The introduction of `controller_t` also allows to make the addition of
colorizers/formatters/reporters more flexible: simply define it and
then add it with a lambda that changes the corresponding settings.
This allows to get rid of all the code about colorizers/formatters/reporters
in different places of the bandit source and hence error-prone, and
it now allows that users may define their own colorizers/formatters/reporters
and register them.

Note that `controller_t` is called `settings_t` at the beginning of the
branch and it is renamed afterwards.

Also note that despite the advantages, a disadvantage is that the specs
became a little more awkward now.