### PR TITLE
Allow multiple go_bandit()s and thus unity builds

### DIFF
--- a/bandit/registration/registrar.h
+++ b/bandit/registration/registrar.h
@@ -13,8 +13,12 @@ namespace bandit {
   }
 }
 
+#define BANDIT_CONCAT2(a, b) a##b
+#define BANDIT_CONCAT(a, b) BANDIT_CONCAT2(a, b)
+#define BANDIT_ADD_COUNTER(a) SNOWHOUSE_CONCAT(a, __COUNTER__)
+
 #define go_bandit \
-  static bandit::detail::spec_registrar bandit_registrar
+  static bandit::detail::spec_registrar BANDIT_ADD_COUNTER(bandit_registrar_)
 
 #define SPEC_BEGIN(name) \
   go_bandit([]{


### PR DESCRIPTION
Unity builds (as provided by cotire's "all_unity" target) save
about 50% of the compilation/linking time and allow better
optimization.