### PR TITLE
Use virtual destructors in interfaces

### DIFF
--- a/bandit/adapters/interface.h
+++ b/bandit/adapters/interface.h
@@ -6,6 +6,8 @@
 namespace bandit {
   namespace adapter {
     struct interface {
+      virtual ~interface() = default;
+
       virtual void adapt_exceptions(std::function<void()>) = 0;
     };
   }

--- a/bandit/colorizers/interface.h
+++ b/bandit/colorizers/interface.h
@@ -6,6 +6,8 @@
 namespace bandit {
   namespace colorizer {
     struct interface {
+      virtual ~interface() = default;
+
       virtual const std::string good() const = 0;
       virtual const std::string neutral() const = 0;
       virtual const std::string info() const = 0;

--- a/bandit/context.h
+++ b/bandit/context.h
@@ -11,7 +11,8 @@
 namespace bandit {
   namespace context {
     struct interface {
-      virtual ~interface() {}
+      virtual ~interface() = default;
+
       virtual const std::string& name() = 0;
       virtual void execution_is_starting() = 0;
       virtual void register_before_each(std::function<void()> func) = 0;

--- a/bandit/failure_formatters/interface.h
+++ b/bandit/failure_formatters/interface.h
@@ -6,6 +6,8 @@
 namespace bandit {
   namespace failure_formatter {
     struct interface {
+      virtual ~interface() = default;
+
       virtual std::string format(const detail::assertion_exception&) const = 0;
     };
   }

--- a/bandit/reporters/interface.h
+++ b/bandit/reporters/interface.h
@@ -7,7 +7,7 @@
 namespace bandit {
   namespace reporter {
     struct interface {
-      virtual ~interface() {}
+      virtual ~interface() = default;
 
       virtual void test_run_starting() = 0;
       virtual void test_run_complete() = 0;

--- a/bandit/run_policies/interface.h
+++ b/bandit/run_policies/interface.h
@@ -16,7 +16,7 @@ namespace bandit {
       interface(interface&& other) : encountered_failure_(other.encountered_failure_) {}
 #endif
 
-      virtual ~interface() {}
+      virtual ~interface() = default;
 
       virtual bool should_run(const std::string& it_name, const context::stack_t& contexts) const = 0;
 

--- a/specs/before_each_after_each.cpp
+++ b/specs/before_each_after_each.cpp
@@ -8,7 +8,7 @@ go_bandit([]() {
 
     before_each([&]() {
       controller.reset(new bandit::detail::controller_t());
-      context = std::unique_ptr<fakes::fake_context>(new fakes::fake_context());
+      context.reset(new fakes::fake_context());
       controller->get_contexts().push_back(context.get());
     });
 

--- a/specs/context.cpp
+++ b/specs/context.cpp
@@ -6,8 +6,7 @@ go_bandit([]() {
 
     before_each([&]() {
       bool hard_skip = false;
-      context = std::unique_ptr<bandit::context::bandit>(
-          new bandit::context::bandit("context name", hard_skip));
+      context.reset(new bandit::context::bandit("context name", hard_skip));
     });
 
     it("is ok to register before_each as it is not executing", [&]() {

--- a/specs/describe.cpp
+++ b/specs/describe.cpp
@@ -17,7 +17,7 @@ describe("describe", []() {
     controller.reset(new bandit::detail::controller_t());
     controller->set_reporter(reporter);
 
-    global_context = std::unique_ptr<fake_context>(new fake_context());
+    global_context.reset(new fake_context());
     controller->get_contexts().push_back(global_context.get());
   });
 

--- a/specs/it.cpp
+++ b/specs/it.cpp
@@ -16,7 +16,7 @@ go_bandit([]() {
       reporter = new fake_reporter();
       controller.reset(new bandit::detail::controller_t());
       controller->set_reporter(reporter);
-      context = std::unique_ptr<fake_context>(new fake_context());
+      context.reset(new fake_context());
       controller->get_contexts().push_back(context.get());
 
       controller->set_policy(new run_policy::always());

--- a/specs/reporters/crash.cpp
+++ b/specs/reporters/crash.cpp
@@ -10,7 +10,7 @@ go_bandit([]() {
 
     before_each([&]() {
       stm.str(std::string());
-      reporter = std::unique_ptr<reporter::crash>(new reporter::crash(stm, formatter));
+      reporter.reset(new reporter::crash(stm, formatter));
     });
 
     auto output = [&]() {

--- a/specs/reporters/dots.cpp
+++ b/specs/reporters/dots.cpp
@@ -188,5 +188,7 @@ go_bandit([]() {
         AssertThat(output(), EndsWith("Test run complete. 1 tests run. 1 succeeded. 1 skipped.\n"));
       });
     });
+
+    reporter.reset(); // necessary so that reporter dtor is called before colorizer dtor
   });
 });

--- a/specs/reporters/dots.cpp
+++ b/specs/reporters/dots.cpp
@@ -10,8 +10,7 @@ go_bandit([]() {
 
     before_each([&]() {
       stm.str(std::string());
-      reporter = std::unique_ptr<reporter::dots>(
-          new reporter::dots(stm, formatter, colorizer));
+      reporter.reset(new reporter::dots(stm, formatter, colorizer));
     });
 
     auto output = [&]() { return stm.str(); };

--- a/specs/reporters/info.cpp
+++ b/specs/reporters/info.cpp
@@ -10,7 +10,7 @@ go_bandit([]() {
 
     before_each([&]() {
       stm.str(std::string());
-      reporter = std::unique_ptr<reporter::info>(new reporter::info(stm, formatter, colorizer));
+      reporter.reset(new reporter::info(stm, formatter, colorizer));
     });
 
     auto output = [&]() {

--- a/specs/reporters/info.cpp
+++ b/specs/reporters/info.cpp
@@ -375,5 +375,7 @@ go_bandit([]() {
         AssertThat(reporter->did_we_pass(), IsTrue());
       });
     });
+
+    reporter.reset(); // necessary so that reporter dtor is called before colorizer dtor
   });
 });

--- a/specs/reporters/singleline.cpp
+++ b/specs/reporters/singleline.cpp
@@ -183,5 +183,7 @@ go_bandit([]() {
         AssertThat(output(), EndsWith("Test run complete. 1 tests run. 1 succeeded. 1 skipped.\n"));
       });
     });
+
+    reporter.reset(); // necessary so that reporter dtor is called before colorizer dtor
   });
 });

--- a/specs/reporters/singleline.cpp
+++ b/specs/reporters/singleline.cpp
@@ -10,8 +10,7 @@ go_bandit([]() {
 
     before_each([&]() {
       stm.str(std::string());
-      reporter = std::unique_ptr<reporter::singleline>(
-          new reporter::singleline(stm, formatter, colorizer));
+      reporter.reset(new reporter::singleline(stm, formatter, colorizer));
     });
 
     auto output = [&]() { return stm.str(); };

--- a/specs/reporters/spec.cpp
+++ b/specs/reporters/spec.cpp
@@ -244,5 +244,7 @@ go_bandit([]() {
         AssertThat(output(), Contains("Test run complete. 1 tests run. 0 succeeded. 1 skipped. 1 failed."));
       });
     });
+
+    reporter.reset(); // necessary so that reporter dtor is called before colorizer dtor
   });
 });

--- a/specs/reporters/spec.cpp
+++ b/specs/reporters/spec.cpp
@@ -10,7 +10,7 @@ go_bandit([]() {
 
     before_each([&]() {
       stm.str(std::string());
-      reporter = std::unique_ptr<reporter::spec>(new reporter::spec(stm, formatter, colorizer));
+      reporter.reset(new reporter::spec(stm, formatter, colorizer));
     });
 
     auto output = [&]() {

--- a/specs/reporters/xunit.cpp
+++ b/specs/reporters/xunit.cpp
@@ -12,7 +12,7 @@ go_bandit([]() {
 
     before_each([&]() {
       stm.str(std::string());
-      reporter = std::unique_ptr<reporter::xunit>(new reporter::xunit(stm, formatter));
+      reporter.reset(new reporter::xunit(stm, formatter));
     });
 
     describe("an empty test run", [&]() {

--- a/specs/run_policies/bandit.cpp
+++ b/specs/run_policies/bandit.cpp
@@ -20,8 +20,8 @@ go_bandit([]() {
       break_on_failure = false;
       dry_run = false;
 
-      contextstack = std::unique_ptr<bandit::context::stack_t>(new bandit::context::stack_t());
-      global_context = std::unique_ptr<bandit::context::interface>(new bandit::context::bandit("", hard_skip));
+      contextstack.reset(new bandit::context::stack_t());
+      global_context.reset(new bandit::context::bandit("", hard_skip));
       contextstack->push_back(global_context.get());
     });
 
@@ -57,7 +57,7 @@ go_bandit([]() {
 
         before_each([&]() {
           hard_skip = true;
-          hard_skip_context = std::unique_ptr<bandit::context::interface>(new bandit::context::bandit("always ignore", hard_skip));
+          hard_skip_context.reset(new bandit::context::bandit("always ignore", hard_skip));
           contextstack->push_back(hard_skip_context.get());
         });
 
@@ -79,7 +79,7 @@ go_bandit([]() {
         std::unique_ptr<bandit::context::interface> current_context;
 
         before_each([&]() {
-          current_context = std::unique_ptr<bandit::context::interface>(new bandit::context::bandit("context matches 'skip'", hard_skip));
+          current_context.reset(new bandit::context::bandit("context matches 'skip'", hard_skip));
           contextstack->push_back(current_context.get());
         });
 
@@ -93,7 +93,7 @@ go_bandit([]() {
         std::unique_ptr<bandit::context::interface> current_context;
 
         before_each([&]() {
-          current_context = std::unique_ptr<bandit::context::interface>(new bandit::context::bandit("context doesn't match", hard_skip));
+          current_context.reset(new bandit::context::bandit("context doesn't match", hard_skip));
           contextstack->push_back(current_context.get());
         });
 
@@ -118,7 +118,7 @@ go_bandit([]() {
         std::unique_ptr<bandit::context::interface> current_context;
 
         before_each([&]() {
-          current_context = std::unique_ptr<bandit::context::interface>(new bandit::context::bandit("context matches 'only'", hard_skip));
+          current_context.reset(new bandit::context::bandit("context matches 'only'", hard_skip));
           contextstack->push_back(current_context.get());
         });
 
@@ -132,7 +132,7 @@ go_bandit([]() {
         std::unique_ptr<bandit::context::interface> current_context;
 
         before_each([&]() {
-          current_context = std::unique_ptr<bandit::context::interface>(new bandit::context::bandit("context doesn't match", hard_skip));
+          current_context.reset(new bandit::context::bandit("context doesn't match", hard_skip));
           contextstack->push_back(current_context.get());
         });
 
@@ -157,7 +157,7 @@ go_bandit([]() {
         std::unique_ptr<bandit::context::interface> current_context;
 
         before_each([&]() {
-          current_context = std::unique_ptr<bandit::context::interface>(new bandit::context::bandit("context", hard_skip));
+          current_context.reset(new bandit::context::bandit("context", hard_skip));
           contextstack->push_back(current_context.get());
         });
 
@@ -176,7 +176,7 @@ go_bandit([]() {
         std::unique_ptr<bandit::context::interface> current_context;
 
         before_each([&]() {
-          current_context = std::unique_ptr<bandit::context::interface>(new bandit::context::bandit("context matches 'skip'", hard_skip));
+          current_context.reset(new bandit::context::bandit("context matches 'skip'", hard_skip));
           contextstack->push_back(current_context.get());
         });
 
@@ -195,7 +195,7 @@ go_bandit([]() {
         std::unique_ptr<bandit::context::interface> current_context;
 
         before_each([&]() {
-          current_context = std::unique_ptr<bandit::context::interface>(new bandit::context::bandit("context matches 'only'", hard_skip));
+          current_context.reset(new bandit::context::bandit("context matches 'only'", hard_skip));
           contextstack->push_back(current_context.get());
         });
 
@@ -215,8 +215,8 @@ go_bandit([]() {
         std::unique_ptr<bandit::context::interface> parent_context;
 
         before_each([&]() {
-          current_context = std::unique_ptr<bandit::context::interface>(new bandit::context::bandit("context matches 'only'", hard_skip));
-          parent_context = std::unique_ptr<bandit::context::interface>(new bandit::context::bandit("context matches 'skip'", hard_skip));
+          current_context.reset(new bandit::context::bandit("context matches 'only'", hard_skip));
+          parent_context.reset(new bandit::context::bandit("context matches 'skip'", hard_skip));
           contextstack->push_back(parent_context.get());
           contextstack->push_back(current_context.get());
         });
@@ -272,7 +272,7 @@ go_bandit([]() {
       });
 
       it("doesn't run if context contains any 'skip' but spec's name matches all 'only'", [&]() {
-        std::unique_ptr<bandit::context::interface> current_context = std::unique_ptr<bandit::context::interface>(new bandit::context::bandit("context matches 'skip1'", hard_skip));
+        std::unique_ptr<bandit::context::interface> current_context{new bandit::context::bandit("context matches 'skip1'", hard_skip)};
         contextstack->push_back(current_context.get());
         run_policy::bandit policy = create_policy();
         AssertThat(policy.should_run("it name only1 only2", *contextstack), IsFalse());


### PR DESCRIPTION
In some interfaces, the declaration of virtual destructors has been forgotten.
They are now added which revealed another bug in some specs
where the colorizer can be destructed before the reporter using that colorizer
is destructed.
This bug is also fixed.

This PR also fixes a readability issue with `std::unique_ptr` assignments.