### PR TITLE
Make Qt Creator formatter (POSIX formatter with file://)

### DIFF
--- a/bandit/failure_formatters.h
+++ b/bandit/failure_formatters.h
@@ -3,5 +3,6 @@
 
 #include "failure_formatters/posix.h"
 #include "failure_formatters/visual_studio.h"
+#include "failure_formatters/qt_creator.h"
 
 #endif

--- a/bandit/failure_formatters/posix.h
+++ b/bandit/failure_formatters/posix.h
@@ -10,7 +10,7 @@ namespace bandit {
       std::string format(const detail::assertion_exception& err) const override {
         std::stringstream ss;
         if (err.file_name().size()) {
-          ss << err.file_name();
+          ss << "file://" << err.file_name();
 
           if (err.line_number()) {
             ss << ":" << err.line_number();

--- a/bandit/failure_formatters/qt_creator.h
+++ b/bandit/failure_formatters/qt_creator.h
@@ -1,16 +1,16 @@
-#ifndef BANDIT_FAILURE_FORMATTERS_POSIX_H
-#define BANDIT_FAILURE_FORMATTERS_POSIX_H
+#ifndef BANDIT_FAILURE_FORMATTERS_QT_H
+#define BANDIT_FAILURE_FORMATTERS_QT_H
 
 #include <sstream>
 #include <bandit/failure_formatters/interface.h>
 
 namespace bandit {
   namespace failure_formatter {
-    struct posix : public interface {
+    struct qt_creator : public interface {
       std::string format(const detail::assertion_exception& err) const override {
         std::stringstream ss;
         if (err.file_name().size()) {
-          ss << err.file_name();
+          ss << "file://" << err.file_name();
 
           if (err.line_number()) {
             ss << ":" << err.line_number();

--- a/bandit/failure_formatters/qt_creator.h
+++ b/bandit/failure_formatters/qt_creator.h
@@ -1,5 +1,5 @@
-#ifndef BANDIT_FAILURE_FORMATTERS_QT_H
-#define BANDIT_FAILURE_FORMATTERS_QT_H
+#ifndef BANDIT_FAILURE_FORMATTERS_QT_CREATOR_H
+#define BANDIT_FAILURE_FORMATTERS_QT_CREATOR_H
 
 #include <sstream>
 #include <bandit/failure_formatters/interface.h>

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -52,6 +52,9 @@ namespace bandit {
   }
 
   inline void use_default_formatters(detail::choice_options& choices) {
+    choices.formatters.add("qt", [&](detail::controller_t& controller) {
+      controller.set_formatter(new failure_formatter::qt_creator());
+    });
     choices.formatters.add("vs", [&](detail::controller_t& controller) {
       controller.set_formatter(new failure_formatter::visual_studio());
     });

--- a/docs/runningtests.md
+++ b/docs/runningtests.md
@@ -17,14 +17,14 @@ USAGE: <executable> [options]
 Options:
   --version,               Print version of bandit
   --help,                  Print usage and exit.
-  --reporter=<reporter>,   Select reporter: crash, dots, singleline, xunit,
-                           info, spec
-  --colorizer=<colorizer>, Select color theme: off, light, dark
-  --formatter=<formatter>, Select error formatter: posix, qt, vs
   --skip=<substring>,      Skip all 'describe' and 'it' containing substring
   --only=<substring>,      Run only 'describe' and 'it' containing substring
   --break-on-failure,      Stop test run on first failing test
   --dry-run,               Skip all tests. Use to list available tests
+  --reporter=<reporter>,   Select reporter: crash, dots, info, singleline, spec,
+                           xunit
+  --colorizer=<colorizer>, Select color theme: dark, light, off
+  --formatter=<formatter>, Select error formatter: posix, qt, vs
 ```
 
 ## Running a subset of the tests

--- a/docs/runningtests.md
+++ b/docs/runningtests.md
@@ -20,7 +20,7 @@ Options:
   --reporter=<reporter>,   Select reporter: crash, dots, singleline, xunit,
                            info, spec
   --colorizer=<colorizer>, Select color theme: off, light, dark
-  --formatter=<formatter>, Select error formatter: posix, vs
+  --formatter=<formatter>, Select error formatter: posix, vs, qt
   --skip=<substring>,      Skip all 'describe' and 'it' containing substring
   --only=<substring>,      Run only 'describe' and 'it' containing substring
   --break-on-failure,      Stop test run on first failing test

--- a/docs/runningtests.md
+++ b/docs/runningtests.md
@@ -20,7 +20,7 @@ Options:
   --reporter=<reporter>,   Select reporter: crash, dots, singleline, xunit,
                            info, spec
   --colorizer=<colorizer>, Select color theme: off, light, dark
-  --formatter=<formatter>, Select error formatter: posix, vs, qt
+  --formatter=<formatter>, Select error formatter: posix, qt, vs
   --skip=<substring>,      Skip all 'describe' and 'it' containing substring
   --only=<substring>,      Run only 'describe' and 'it' containing substring
   --break-on-failure,      Stop test run on first failing test
@@ -110,6 +110,16 @@ The POSIX formatter reports errors as
 
 This matches how gcc and clang reports errors.
 This formatter is the default.
+
+#### `--formatter=qt`
+
+The Qt Creator formatter reports errors as
+
+```
+file://<filename>:<line>: <error message>
+```
+
+It enables hyperlink from the console ouptut to jump directly to the error.
 
 #### `--formatter=vs`
 

--- a/specs/failure_formatters/qt_creator.cpp
+++ b/specs/failure_formatters/qt_creator.cpp
@@ -2,7 +2,7 @@
 namespace bd = bandit::detail;
 
 go_bandit([]() {
-  describe("qt creator failure formatter", [&]() {
+  describe("Qt Creator failure formatter", [&]() {
     failure_formatter::qt_creator formatter;
 
     it("formats assertions with file and line number", [&]() {

--- a/specs/failure_formatters/qt_creator.cpp
+++ b/specs/failure_formatters/qt_creator.cpp
@@ -7,7 +7,7 @@ go_bandit([]() {
 
     it("formats assertions with file and line number", [&]() {
       bd::assertion_exception exception("message", "file", 321);
-      AssertThat(formatter.format(exception), Equals("file:321: message"));
+      AssertThat(formatter.format(exception), Equals("file://file:321: message"));
     });
 
     it("formats assertions without file and line number", [&]() {

--- a/specs/failure_formatters/qt_creator.cpp
+++ b/specs/failure_formatters/qt_creator.cpp
@@ -1,0 +1,18 @@
+#include <specs/specs.h>
+namespace bd = bandit::detail;
+
+go_bandit([]() {
+  describe("qt creator failure formatter", [&]() {
+    failure_formatter::qt_creator formatter;
+
+    it("formats assertions with file and line number", [&]() {
+      bd::assertion_exception exception("message", "file", 321);
+      AssertThat(formatter.format(exception), Equals("file:321: message"));
+    });
+
+    it("formats assertions without file and line number", [&]() {
+      bd::assertion_exception exception("message");
+      AssertThat(formatter.format(exception), Equals("message"));
+    });
+  });
+});

--- a/specs/options.cpp
+++ b/specs/options.cpp
@@ -151,7 +151,7 @@ go_bandit([]() {
         using slpair = std::pair<std::string, std::vector<std::string>>;
         for (auto pair : {
                  slpair{"colorizer", {"off", "dark", "light"}},
-                 slpair{"formatter", {"posix", "vs"}},
+                 slpair{"formatter", {"posix", "vs", "qt"}},
                  slpair{"reporter", {"singleline", "xunit", "info", "spec", "crash", "dots"}}}) {
           for (std::string name : pair.second) {
             it("works with known " + pair.first + " '" + name + "'", [&] {


### PR DESCRIPTION
Adding the `file://` prefix before a file name allows to enable hyperlink on the Qt Creator output log which make very convenient to find failing test.

What do you think of this feature? Would it be annoying for people not using Qt Creator?