### PR TITLE
Fix dangling pointer

### DIFF
--- a/bandit/controller.h
+++ b/bandit/controller.h
@@ -146,6 +146,10 @@ namespace bandit {
         get_controller_address() = controller;
       }
 
+      static void deregister_controller() {
+        get_controller_address() = nullptr;
+      }
+
       static controller_t& registered_controller() {
         auto controller = get_controller_address();
         throw_if_nullptr(controller, "controller", "bandit::detail::register_controller()");
@@ -199,6 +203,10 @@ namespace bandit {
 
     inline void register_controller(controller_t* controller) {
       controller_t::register_controller(controller);
+    }
+
+    inline void deregister_controller() {
+      controller_t::deregister_controller();
     }
 
     inline controller_t& registered_controller() {

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -110,7 +110,10 @@ namespace bandit {
     controller.set_policy(new run_policy::bandit(opt.filter_chain(), opt.break_on_failure(), opt.dry_run()));
 
     detail::register_controller(&controller);
-    return run(opt, detail::specs());
+    int result = run(opt, detail::specs());
+    detail::deregister_controller();
+
+    return result;
   }
 
   inline int run(int argc, char* argv[], bool allow_further = true) {


### PR DESCRIPTION
The address of the local variable `controller` is still referenced to by the static variable `controller_` after `run()` is executed and controller has been deallocated.

This issue was detected in a [sonarcloud run for the OGDF](https://sonarcloud.io/project/issues?pullRequest=105&id=ogdf_ogdf&open=AYubJkdaAtK6-GxC6FiI). It's not that problematic because `controller_` should not be touched again after `run()` has been executed, but it's the only bug in bandit that sonarcloud detected so I thought that it is worth fixing. Please check whether my changes actually make sense; I'm not that familiar with the bandit code base.